### PR TITLE
added option to have a label key via command line

### DIFF
--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
@@ -169,6 +169,13 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Path to write Newick-formatted output to.",
     )
     parser.add_argument(
+        "-l",
+        "--label-key",
+        type=str,
+        help="Name of column to use as taxon label.",
+        required=False
+    )
+    parser.add_argument(
         "-v",
         "--version",
         action="version",
@@ -201,7 +208,7 @@ if __name__ == "__main__":
     ):
         logging.info("converting to Newick format...")
         newick_str = alifestd_as_newick_asexual(
-            phylogeny_df, progress_wrap=tqdm
+            phylogeny_df, progress_wrap=tqdm, label_key=args.label_key
         )
 
     logging.info(f"writing Newick-formatted data to {args.output_file}...")

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
@@ -71,7 +71,7 @@ def alifestd_as_newick_asexual(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
     *,
-    label_key: typing.Optional[str] = None,
+    taxon_label: typing.Optional[str] = None,
     progress_wrap=lambda x: x,
 ) -> str:
     """Convert phylogeny dataframe to Newick format.
@@ -82,7 +82,7 @@ def alifestd_as_newick_asexual(
         Phylogeny dataframe in Alife standard format.
     mutate : bool, optional
         Allow in-place mutations of the input dataframe, by default False.
-    label_key : str, optional
+    taxon_label : str, optional
         Column to use for taxon labels, by default None.
     progress_wrap : typing.Callable, optional
         Pass tqdm or equivalent to display a progress bar.
@@ -121,7 +121,7 @@ def alifestd_as_newick_asexual(
 
     logging.info("preparing labels...")
     phylogeny_df["__hstrat_label"] = opyt.apply_if_or_value(
-        label_key, phylogeny_df.__getitem__, ""
+        taxon_label, phylogeny_df.__getitem__, ""
     )
     phylogeny_df["__hstrat_label"] = phylogeny_df["__hstrat_label"].astype(str)
 
@@ -170,10 +170,10 @@ def _create_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "-l",
-        "--label-key",
+        "--taxon-label",
         type=str,
         help="Name of column to use as taxon label.",
-        required=False
+        required=False,
     )
     parser.add_argument(
         "-v",
@@ -208,7 +208,7 @@ if __name__ == "__main__":
     ):
         logging.info("converting to Newick format...")
         newick_str = alifestd_as_newick_asexual(
-            phylogeny_df, progress_wrap=tqdm, label_key=args.label_key
+            phylogeny_df, progress_wrap=tqdm, taxon_label=args.taxon_label
         )
 
     logging.info(f"writing Newick-formatted data to {args.output_file}...")

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_as_newick_asexual.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_as_newick_asexual.py
@@ -28,7 +28,7 @@ def test_fuzz(phylogeny_df: pd.DataFrame):
     phylogeny_df = alifestd_try_add_ancestor_id_col(phylogeny_df)
     original = phylogeny_df.copy()
 
-    result = alifestd_as_newick_asexual(phylogeny_df, label_key="id")
+    result = alifestd_as_newick_asexual(phylogeny_df, taxon_label="id")
     assert original.equals(phylogeny_df)
 
     rosetta_tree = apc.RosettaTree.from_newick(result)
@@ -65,7 +65,7 @@ def test_simple1(mutate: bool):
     original_df = phylogeny_df.copy()
     result = alifestd_as_newick_asexual(
         phylogeny_df,
-        label_key=None,
+        taxon_label=None,
         mutate=mutate,
     )
     assert result == "((:1):4):3.1;"
@@ -85,7 +85,7 @@ def test_simple2(mutate: bool):
     original_df = phylogeny_df.copy()
     result = alifestd_as_newick_asexual(
         phylogeny_df,
-        label_key=None,
+        taxon_label=None,
         mutate=mutate,
     )
     assert result == "(,());"
@@ -106,7 +106,7 @@ def test_simple3(mutate: bool):
     original_df = phylogeny_df.copy()
     result = alifestd_as_newick_asexual(
         phylogeny_df,
-        label_key="label",
+        taxon_label="label",
         mutate=mutate,
     )
     assert result == "(D)A;\n(C)B;"
@@ -128,7 +128,7 @@ def test_simple4(mutate: bool):
     result = alifestd_as_newick_asexual(
         phylogeny_df,
         mutate=mutate,
-        label_key="id",
+        taxon_label="id",
     )
 
     assert result == "(4:90,2:2,(3:4)1:1)0:0;"

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_as_newick_asexual_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_as_newick_asexual_cli.py
@@ -39,6 +39,8 @@ def test_alifestd_as_newick_asexual_cli_version():
         "nk_lexicaseselection.csv",
         "nk_tournamentselection.csv",
     ],
+)
+@pytest.mark.parametrize(
     "taxon_label",
     [
         None,

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_as_newick_asexual_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_as_newick_asexual_cli.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import subprocess
+import typing
 
 import pytest
 
@@ -38,20 +39,27 @@ def test_alifestd_as_newick_asexual_cli_version():
         "nk_lexicaseselection.csv",
         "nk_tournamentselection.csv",
     ],
+    "taxon_label",
+    [
+        None,
+        "id",
+    ],
 )
-def test_alifestd_as_newick_asexual_cli_csv(input_file: str):
+def test_alifestd_as_newick_asexual_cli_csv(
+    input_file: str, taxon_label: typing.Optional[str]
+):
     output_file = f"/tmp/hstrat-{input_file}.newick"
     pathlib.Path(output_file).unlink(missing_ok=True)
-    subprocess.run(
-        [
-            "python3",
-            "-m",
-            "hstrat._auxiliary_lib._alifestd_as_newick_asexual",
-            "--input-file",
-            f"{assets}/{input_file}",
-            "-o",
-            output_file,
-        ],
-        check=True,
-    )
+    cmd = [
+        "python3",
+        "-m",
+        "hstrat._auxiliary_lib._alifestd_as_newick_asexual",
+        "--input-file",
+        f"{assets}/{input_file}",
+        "-o",
+        output_file,
+    ]
+    if taxon_label is not None:
+        cmd.extend(["--taxon-label", taxon_label])
+    subprocess.run(cmd, check=True)
     assert os.path.exists(output_file)


### PR DESCRIPTION
Simply makes it so that you can call `python3 -m hstrat._auxiliary_lib._alifestd_as_newick_asexual` with the argument `--label-key`, which helps you labelthe newick tree