### PR TITLE
Fix scipy build failure in manylinux2014 CI wheel tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -378,15 +378,13 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.3
         env:
           # workaround pyarrow wheel issue
-          # install scipy-openblas32 and scipy to prevent scipy source
-          # build failures in manylinux2014 containers without OpenBLAS
+          # pre-install scipy with --only-binary to avoid source builds
+          # failing in manylinux2014 containers without OpenBLAS
           CIBW_BEFORE_TEST: |
             python -m pip install --upgrade pip
             python -m pip --version
             python -m pip install "pyarrow==19.0.1"
-            python -m pip install scipy-openblas32
-            export PKG_CONFIG_PATH="$(python -c 'import scipy_openblas32; print(scipy_openblas32.get_pkg_config())')"
-            python -m pip install scipy
+            python -m pip install --only-binary scipy scipy
           CIBW_TEST_COMMAND: python3 -m hstrat.dataframe.surface_unpack_reconstruct --help
           CIBW_TEST_SKIP: "*313-* pp* *win* *i686* *musllinux*"
           CIBW_SKIP: "*-win32"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -378,10 +378,15 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.3
         env:
           # workaround pyarrow wheel issue
+          # install scipy-openblas32 and scipy to prevent scipy source
+          # build failures in manylinux2014 containers without OpenBLAS
           CIBW_BEFORE_TEST: |
             python -m pip install --upgrade pip
             python -m pip --version
             python -m pip install "pyarrow==19.0.1"
+            python -m pip install scipy-openblas32
+            export PKG_CONFIG_PATH="$(python -c 'import scipy_openblas32; print(scipy_openblas32.get_pkg_config())')"
+            python -m pip install scipy
           CIBW_TEST_COMMAND: python3 -m hstrat.dataframe.surface_unpack_reconstruct --help
           CIBW_TEST_SKIP: "*313-* pp* *win* *i686* *musllinux*"
           CIBW_SKIP: "*-win32"


### PR DESCRIPTION
scipy 1.17.0 has no pre-built manylinux2014 wheels for cp311+, causing source builds to fail due to missing OpenBLAS in the container. Install scipy-openblas32 and pre-build scipy in CIBW_BEFORE_TEST so it's already satisfied when the hstrat wheel dependencies are installed.

https://claude.ai/code/session_019ztWtY8HcBV5EzYdP357EV