### PR TITLE
Update bad type hints

### DIFF
--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -1,7 +1,6 @@
 import logging
 import warnings
 
-import pandas as pd
 import polars as pl
 
 from ._alifestd_assign_contiguous_ids_polars import (
@@ -11,8 +10,8 @@ from ._alifestd_collapse_unifurcations import _collapse_unifurcations
 
 
 def alifestd_collapse_unifurcations_polars(
-    phylogeny_df: pd.DataFrame,
-) -> pd.DataFrame:
+    phylogeny_df: pl.DataFrame,
+) -> pl.DataFrame:
     """Pare record to bypass organisms with one ancestor and one descendant.
 
     Input dataframe is not mutated by this operation unless `mutate` set True.

--- a/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual_polars.py
@@ -1,14 +1,13 @@
 import logging
 
-import pandas as pd
 import polars as pl
 
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 
 
 def alifestd_delete_trunk_asexual_polars(
-    phylogeny_df: pd.DataFrame,
-) -> pd.DataFrame:
+    phylogeny_df: pl.DataFrame,
+) -> pl.DataFrame:
     """Delete entries masked by `is_trunk` column.
 
     Masked entries must be contiguous, meaning that no non-trunk entry can

--- a/hstrat/_auxiliary_lib/_alifestd_prefix_roots_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prefix_roots_polars.py
@@ -5,16 +5,15 @@ import warnings
 
 import numpy as np
 import opytional as opyt
-import pandas as pd
 import polars as pl
 
 
 def alifestd_prefix_roots_polars(
-    phylogeny_df: pd.DataFrame,
+    phylogeny_df: pl.DataFrame,
     *,
     allow_id_reassign: bool = False,
     origin_time: typing.Optional[numbers.Real] = None,
-) -> pd.DataFrame:
+) -> pl.DataFrame:
     """Add new roots to the phylogeny, prefixing existing roots.
 
     An origin time may be specified, in which case only roots with origin times

--- a/hstrat/_auxiliary_lib/_get_sole_scalar_value_polars.py
+++ b/hstrat/_auxiliary_lib/_get_sole_scalar_value_polars.py
@@ -1,7 +1,11 @@
+import typing
+
 import polars as pl
 
 
-def get_sole_scalar_value_polars(df: pl.DataFrame, col_name: str) -> int:
+def get_sole_scalar_value_polars(
+    df: pl.DataFrame, col_name: str
+) -> typing.Any:
     """Get scalar value from DataFrame, ensuring it is unique."""
     if df.lazy().limit(1).collect().is_empty():
         raise ValueError(f"DataFrame is empty, cannot get {col_name}")


### PR DESCRIPTION
## Summary
This PR migrates several auxiliary library functions from pandas to polars, updating type annotations and removing pandas dependencies where they are no longer needed.

## Key Changes
- **`_get_sole_scalar_value_polars.py`**: Updated return type annotation from `int` to `typing.Any` to be more flexible with scalar value types
- **`_alifestd_collapse_unifurcations_polars.py`**: Changed function signature to accept and return `pl.DataFrame` instead of `pd.DataFrame`; removed unused pandas import
- **`_alifestd_delete_trunk_asexual_polars.py`**: Changed function signature to accept and return `pl.DataFrame` instead of `pd.DataFrame`; removed unused pandas import
- **`_alifestd_prefix_roots_polars.py`**: Changed function signature to accept and return `pl.DataFrame` instead of `pd.DataFrame`; removed unused pandas import

## Implementation Details
All changes maintain the polars-based implementation while correcting the type hints to accurately reflect that these functions work with polars DataFrames rather than pandas DataFrames. The removal of pandas imports indicates these functions no longer have any pandas dependencies.

https://claude.ai/code/session_01VnJY1C9BK9AhN18gzNA3JW