### PR TITLE
Expand collapse_unifurcations warning to cover all topology-dependent columns

### DIFF
--- a/hstrat/__main__.py
+++ b/hstrat/__main__.py
@@ -18,6 +18,8 @@ $ python3 -m hstrat._auxiliary_lib._alifestd_count_root_nodes
 $ python3 -m hstrat._auxiliary_lib._alifestd_downsample_tips_asexual
 $ python3 -m hstrat._auxiliary_lib._alifestd_downsample_tips_clade_asexual
 $ python3 -m hstrat._auxiliary_lib._alifestd_downsample_tips_polars
+$ python3 -m hstrat._auxiliary_lib._alifestd_drop_topological_sensitivity
+$ python3 -m hstrat._auxiliary_lib._alifestd_drop_topological_sensitivity_polars
 $ python3 -m hstrat._auxiliary_lib._alifestd_join_roots
 $ python3 -m hstrat._auxiliary_lib._alifestd_mark_leaves
 $ python3 -m hstrat._auxiliary_lib._alifestd_mark_leaves_polars

--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -57,6 +57,9 @@ from ._alifestd_categorize_triplet_asexual import (
 from ._alifestd_check_topological_sensitivity import (
     alifestd_check_topological_sensitivity,
 )
+from ._alifestd_check_topological_sensitivity_polars import (
+    alifestd_check_topological_sensitivity_polars,
+)
 from ._alifestd_chronological_sort import alifestd_chronological_sort
 from ._alifestd_coarsen_mask import alifestd_coarsen_mask
 from ._alifestd_coarsen_taxa_asexual import (
@@ -280,6 +283,9 @@ from ._alifestd_validate import alifestd_validate
 from ._alifestd_warn_topological_sensitivity import (
     alifestd_warn_topological_sensitivity,
 )
+from ._alifestd_warn_topological_sensitivity_polars import (
+    alifestd_warn_topological_sensitivity_polars,
+)
 from ._all_same import all_same
 from ._all_unique import all_unique
 from ._anynode_deepcopy_except_neighbors import (
@@ -436,6 +442,7 @@ __all__ = [
     "alifestd_calc_triplet_distance_asexual",
     "alifestd_categorize_triplet_asexual",
     "alifestd_check_topological_sensitivity",
+    "alifestd_check_topological_sensitivity_polars",
     "alifestd_chronological_sort",
     "alifestd_coarsen_mask",
     "alifestd_coarsen_taxa_asexual",
@@ -543,6 +550,7 @@ __all__ = [
     "alifestd_unfurl_traversal_semiorder_asexual",
     "alifestd_validate",
     "alifestd_warn_topological_sensitivity",
+    "alifestd_warn_topological_sensitivity_polars",
     "all_same",
     "all_unique",
     "anynode_deepcopy_except_neighbors",

--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -54,6 +54,9 @@ from ._alifestd_calc_triplet_distance_asexual import (
 from ._alifestd_categorize_triplet_asexual import (
     alifestd_categorize_triplet_asexual,
 )
+from ._alifestd_check_topological_sensitivity import (
+    alifestd_check_topological_sensitivity,
+)
 from ._alifestd_chronological_sort import alifestd_chronological_sort
 from ._alifestd_coarsen_mask import alifestd_coarsen_mask
 from ._alifestd_coarsen_taxa_asexual import (
@@ -94,6 +97,12 @@ from ._alifestd_downsample_tips_clade_asexual import (
     alifestd_downsample_tips_clade_asexual,
 )
 from ._alifestd_downsample_tips_polars import alifestd_downsample_tips_polars
+from ._alifestd_drop_topological_sensitivity import (
+    alifestd_drop_topological_sensitivity,
+)
+from ._alifestd_drop_topological_sensitivity_polars import (
+    alifestd_drop_topological_sensitivity_polars,
+)
 from ._alifestd_estimate_triplet_distance_asexual import (
     alifestd_estimate_triplet_distance_asexual,
 )
@@ -268,6 +277,9 @@ from ._alifestd_unfurl_traversal_semiorder_asexual import (
     alifestd_unfurl_traversal_semiorder_asexual,
 )
 from ._alifestd_validate import alifestd_validate
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._all_same import all_same
 from ._all_unique import all_unique
 from ._anynode_deepcopy_except_neighbors import (
@@ -423,6 +435,7 @@ __all__ = [
     "alifestd_calc_polytomic_index",
     "alifestd_calc_triplet_distance_asexual",
     "alifestd_categorize_triplet_asexual",
+    "alifestd_check_topological_sensitivity",
     "alifestd_chronological_sort",
     "alifestd_coarsen_mask",
     "alifestd_coarsen_taxa_asexual",
@@ -444,6 +457,8 @@ __all__ = [
     "alifestd_downsample_tips_asexual",
     "alifestd_downsample_tips_clade_asexual",
     "alifestd_downsample_tips_polars",
+    "alifestd_drop_topological_sensitivity",
+    "alifestd_drop_topological_sensitivity_polars",
     "alifestd_estimate_triplet_distance_asexual",
     "alifestd_find_chronological_inconsistency",
     "alifestd_find_leaf_ids",
@@ -527,6 +542,7 @@ __all__ = [
     "alifestd_unfurl_traversal_postorder_asexual",
     "alifestd_unfurl_traversal_semiorder_asexual",
     "alifestd_validate",
+    "alifestd_warn_topological_sensitivity",
     "all_same",
     "all_unique",
     "anynode_deepcopy_except_neighbors",

--- a/hstrat/_auxiliary_lib/_add_bool_arg.py
+++ b/hstrat/_auxiliary_lib/_add_bool_arg.py
@@ -1,0 +1,31 @@
+import argparse
+
+
+def add_bool_arg(
+    parser: argparse.ArgumentParser,
+    name: str,
+    default: bool = False,
+) -> None:
+    """Add a ``--name/--no-name`` boolean flag pair to *parser*.
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        The argument parser to add the flag to.
+    name : str
+        The flag name (e.g., ``"insert"`` adds ``--insert``/``--no-insert``).
+    default : bool, default False
+        Default value when neither flag is provided.
+    """
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument(
+        "--" + name,
+        dest=name.replace("-", "_"),
+        action="store_true",
+    )
+    group.add_argument(
+        "--no-" + name,
+        dest=name.replace("-", "_"),
+        action="store_false",
+    )
+    parser.set_defaults(**{name.replace("-", "_"): default})

--- a/hstrat/_auxiliary_lib/_add_bool_arg.py
+++ b/hstrat/_auxiliary_lib/_add_bool_arg.py
@@ -1,10 +1,12 @@
 import argparse
 
 
+# adapted from https://stackoverflow.com/a/31347222
 def add_bool_arg(
     parser: argparse.ArgumentParser,
     name: str,
     default: bool = False,
+    help: str = "",
 ) -> None:
     """Add a ``--name/--no-name`` boolean flag pair to *parser*.
 
@@ -16,16 +18,20 @@ def add_bool_arg(
         The flag name (e.g., ``"insert"`` adds ``--insert``/``--no-insert``).
     default : bool, default False
         Default value when neither flag is provided.
+    help : str, default ""
+        Help text shown for the ``--name`` flag.
     """
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument(
         "--" + name,
         dest=name.replace("-", "_"),
         action="store_true",
+        help=help,
     )
     group.add_argument(
         "--no-" + name,
         dest=name.replace("-", "_"),
         action="store_false",
+        help=f"disable --{name}",
     )
     parser.set_defaults(**{name.replace("-", "_"): default})

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
@@ -3,10 +3,10 @@ import typing
 import pandas as pd
 
 # Columns that describe the node-to-parent relationship or position in the
-# existing hierarchy.  These are NOT invalidated by pure insert operations
-# (adding new nodes without changing existing ancestry), but ARE invalidated
-# by delete or update operations.
-_insert_insensitive_cols = frozenset((
+# existing hierarchy.  These are ONLY invalidated by update operations
+# (changing ancestor relationships), NOT by insert (adding new nodes) or
+# delete (removing entire contiguous branches without re-parenting).
+_update_only_sensitive_cols = frozenset((
     "ancestor_origin_time",
     "branch_length",
     "edge_length",
@@ -15,7 +15,7 @@ _insert_insensitive_cols = frozenset((
 ))
 
 # All columns that may be invalidated by topological operations.
-_topologically_sensitive_cols = _insert_insensitive_cols | frozenset((
+_topologically_sensitive_cols = _update_only_sensitive_cols | frozenset((
     "clade_duration",
     "clade_duration_ratio_sister",
     "clade_fblr_growth_children",
@@ -51,10 +51,10 @@ def _get_sensitive_cols(
 ) -> frozenset:
     """Return the set of sensitive column names for the given operation
     types."""
-    if delete or update:
+    if update:
         return _topologically_sensitive_cols
-    elif insert:
-        return _topologically_sensitive_cols - _insert_insensitive_cols
+    elif insert or delete:
+        return _topologically_sensitive_cols - _update_only_sensitive_cols
     else:
         return frozenset()
 

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
@@ -4,8 +4,8 @@ import pandas as pd
 
 # Columns that describe the node-to-parent relationship or position in the
 # existing hierarchy.  These are ONLY invalidated by update operations
-# (changing ancestor relationships), NOT by insert (adding new nodes) or
-# delete (removing entire contiguous branches without re-parenting).
+# (changing ancestor relationships), NOT by pure insert (adding new nodes)
+# or pure delete (removing entire contiguous branches).
 _update_only_sensitive_cols = frozenset((
     "ancestor_origin_time",
     "branch_length",
@@ -68,6 +68,8 @@ def alifestd_check_topological_sensitivity(
 ) -> typing.List[str]:
     """Return names of columns present in `phylogeny_df` that may be
     invalidated by topological operations such as collapsing unifurcations.
+
+    If no such columns exist, returns an empty list.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
@@ -1,7 +1,8 @@
 import typing
 
+import pandas as pd
 
-_topologically_sensitive_cols = [
+_topologically_sensitive_cols = frozenset((
     "ancestor_origin_time",
     "branch_length",
     "clade_duration",
@@ -32,18 +33,23 @@ _topologically_sensitive_cols = [
     "ot_mrca_time_since",
     "right_child_id",
     "sister_id",
-]
+))
 
 
 def alifestd_check_topological_sensitivity(
-    phylogeny_df: typing.Any,
+    phylogeny_df: pd.DataFrame,
 ) -> typing.List[str]:
     """Return names of columns present in `phylogeny_df` that may be
     invalidated by topological operations such as collapsing unifurcations.
 
-    Accepts pandas or polars DataFrames.
-
     Input dataframe is not mutated by this operation.
+
+    See Also
+    --------
+    alifestd_check_topological_sensitivity_polars :
+        Polars-based implementation.
     """
-    columns = phylogeny_df.columns
-    return [col for col in _topologically_sensitive_cols if col in columns]
+    return [
+        col for col in phylogeny_df.columns
+        if col in _topologically_sensitive_cols
+    ]

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
@@ -15,7 +15,8 @@ _update_only_sensitive_cols = frozenset((
 ))
 
 # All columns that may be invalidated by topological operations.
-_topologically_sensitive_cols = _update_only_sensitive_cols | frozenset((
+_topologically_sensitive_cols = frozenset((
+    *_update_only_sensitive_cols,
     "clade_duration",
     "clade_duration_ratio_sister",
     "clade_fblr_growth_children",

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
@@ -3,7 +3,7 @@ import typing
 import pandas as pd
 
 # Columns that describe the node-to-parent relationship or position in the
-# existing hierarchy.  These are ONLY invalidated by update operations
+# existing hierarchy. These are ONLY invalidated by update operations
 # (changing ancestor relationships), NOT by pure insert (adding new nodes)
 # or pure delete (removing entire contiguous branches).
 _update_only_sensitive_cols = frozenset((

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
@@ -6,43 +6,47 @@ import pandas as pd
 # existing hierarchy. These are ONLY invalidated by update operations
 # (changing ancestor relationships), NOT by pure insert (adding new nodes)
 # or pure delete (removing entire contiguous branches).
-_update_only_sensitive_cols = frozenset((
-    "ancestor_origin_time",
-    "branch_length",
-    "edge_length",
-    "node_depth",
-    "origin_time_delta",
-))
+_update_only_sensitive_cols = frozenset(
+    (
+        "ancestor_origin_time",
+        "branch_length",
+        "edge_length",
+        "node_depth",
+        "origin_time_delta",
+    )
+)
 
 # All columns that may be invalidated by topological operations.
-_topologically_sensitive_cols = frozenset((
-    *_update_only_sensitive_cols,
-    "clade_duration",
-    "clade_duration_ratio_sister",
-    "clade_fblr_growth_children",
-    "clade_fblr_growth_sister",
-    "clade_faithpd",
-    "clade_leafcount_ratio_sister",
-    "clade_logistic_growth_children",
-    "clade_logistic_growth_sister",
-    "clade_nodecount_ratio_sister",
-    "clade_subtended_duration",
-    "clade_subtended_duration_ratio_sister",
-    "is_left_child",
-    "is_right_child",
-    "left_child_id",
-    "max_descendant_origin_time",
-    "num_children",
-    "num_descendants",
-    "num_leaves",
-    "num_leaves_sibling",
-    "num_preceding_leaves",
-    "ot_mrca_id",
-    "ot_mrca_time_of",
-    "ot_mrca_time_since",
-    "right_child_id",
-    "sister_id",
-))
+_topologically_sensitive_cols = frozenset(
+    (
+        *_update_only_sensitive_cols,
+        "clade_duration",
+        "clade_duration_ratio_sister",
+        "clade_fblr_growth_children",
+        "clade_fblr_growth_sister",
+        "clade_faithpd",
+        "clade_leafcount_ratio_sister",
+        "clade_logistic_growth_children",
+        "clade_logistic_growth_sister",
+        "clade_nodecount_ratio_sister",
+        "clade_subtended_duration",
+        "clade_subtended_duration_ratio_sister",
+        "is_left_child",
+        "is_right_child",
+        "left_child_id",
+        "max_descendant_origin_time",
+        "num_children",
+        "num_descendants",
+        "num_leaves",
+        "num_leaves_sibling",
+        "num_preceding_leaves",
+        "ot_mrca_id",
+        "ot_mrca_time_of",
+        "ot_mrca_time_since",
+        "right_child_id",
+        "sister_id",
+    )
+)
 
 
 def _get_sensitive_cols(insert: bool, delete: bool, update: bool) -> frozenset:
@@ -87,7 +91,4 @@ def alifestd_check_topological_sensitivity(
         Polars-based implementation.
     """
     sensitive = _get_sensitive_cols(insert, delete, update)
-    return [
-        col for col in phylogeny_df.columns
-        if col in sensitive
-    ]
+    return [col for col in phylogeny_df.columns if col in sensitive]

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
@@ -1,0 +1,49 @@
+import typing
+
+
+_topologically_sensitive_cols = [
+    "ancestor_origin_time",
+    "branch_length",
+    "clade_duration",
+    "clade_duration_ratio_sister",
+    "clade_fblr_growth_children",
+    "clade_fblr_growth_sister",
+    "clade_faithpd",
+    "clade_leafcount_ratio_sister",
+    "clade_logistic_growth_children",
+    "clade_logistic_growth_sister",
+    "clade_nodecount_ratio_sister",
+    "clade_subtended_duration",
+    "clade_subtended_duration_ratio_sister",
+    "edge_length",
+    "is_left_child",
+    "is_right_child",
+    "left_child_id",
+    "max_descendant_origin_time",
+    "node_depth",
+    "num_children",
+    "num_descendants",
+    "num_leaves",
+    "num_leaves_sibling",
+    "num_preceding_leaves",
+    "origin_time_delta",
+    "ot_mrca_id",
+    "ot_mrca_time_of",
+    "ot_mrca_time_since",
+    "right_child_id",
+    "sister_id",
+]
+
+
+def alifestd_check_topological_sensitivity(
+    phylogeny_df: typing.Any,
+) -> typing.List[str]:
+    """Return names of columns present in `phylogeny_df` that may be
+    invalidated by topological operations such as collapsing unifurcations.
+
+    Accepts pandas or polars DataFrames.
+
+    Input dataframe is not mutated by this operation.
+    """
+    columns = phylogeny_df.columns
+    return [col for col in _topologically_sensitive_cols if col in columns]

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity.py
@@ -45,11 +45,7 @@ _topologically_sensitive_cols = frozenset((
 ))
 
 
-def _get_sensitive_cols(
-    insert: bool,
-    delete: bool,
-    update: bool,
-) -> frozenset:
+def _get_sensitive_cols(insert: bool, delete: bool, update: bool) -> frozenset:
     """Return the set of sensitive column names for the given operation
     types."""
     if update:

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity_polars.py
@@ -2,18 +2,31 @@ import typing
 
 import polars as pl
 
-from ._alifestd_check_topological_sensitivity import (
-    _topologically_sensitive_cols,
-)
+from ._alifestd_check_topological_sensitivity import _get_sensitive_cols
 
 
 def alifestd_check_topological_sensitivity_polars(
     phylogeny_df: typing.Union[pl.DataFrame, pl.LazyFrame],
+    *,
+    insert: bool,
+    delete: bool,
+    update: bool,
 ) -> typing.List[str]:
     """Return names of columns present in `phylogeny_df` that may be
     invalidated by topological operations such as collapsing unifurcations.
 
     Accepts polars DataFrames and LazyFrames.
+
+    Parameters
+    ----------
+    phylogeny_df : polars.DataFrame or polars.LazyFrame
+        The phylogeny as a dataframe in alife standard format.
+    insert : bool
+        Whether the operation inserts new nodes.
+    delete : bool
+        Whether the operation deletes nodes.
+    update : bool
+        Whether the operation updates ancestor relationships.
 
     Input dataframe is not mutated by this operation.
 
@@ -22,10 +35,9 @@ def alifestd_check_topological_sensitivity_polars(
     alifestd_check_topological_sensitivity :
         Pandas-based implementation.
     """
+    sensitive = _get_sensitive_cols(insert, delete, update)
     if isinstance(phylogeny_df, pl.LazyFrame):
         columns = phylogeny_df.collect_schema().names()
     else:
         columns = phylogeny_df.columns
-    return [
-        col for col in columns if col in _topologically_sensitive_cols
-    ]
+    return [col for col in columns if col in sensitive]

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity_polars.py
@@ -38,9 +38,5 @@ def alifestd_check_topological_sensitivity_polars(
         Pandas-based implementation.
     """
     sensitive = _get_sensitive_cols(insert, delete, update)
-    columns = (
-        phylogeny_df.collect_schema().names()
-        if isinstance(phylogeny_df, pl.LazyFrame)
-        else phylogeny_df.columns
-    )
+    columns = phylogeny_df.lazy().collect_schema().names()
     return [col for col in columns if col in sensitive]

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity_polars.py
@@ -17,6 +17,8 @@ def alifestd_check_topological_sensitivity_polars(
 
     Accepts polars DataFrames and LazyFrames.
 
+    If no such columns exist, returns an empty list.
+
     Parameters
     ----------
     phylogeny_df : polars.DataFrame or polars.LazyFrame
@@ -36,8 +38,9 @@ def alifestd_check_topological_sensitivity_polars(
         Pandas-based implementation.
     """
     sensitive = _get_sensitive_cols(insert, delete, update)
-    if isinstance(phylogeny_df, pl.LazyFrame):
-        columns = phylogeny_df.collect_schema().names()
-    else:
-        columns = phylogeny_df.columns
+    columns = (
+        phylogeny_df.collect_schema().names()
+        if isinstance(phylogeny_df, pl.LazyFrame)
+        else phylogeny_df.columns
+    )
     return [col for col in columns if col in sensitive]

--- a/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_check_topological_sensitivity_polars.py
@@ -1,0 +1,31 @@
+import typing
+
+import polars as pl
+
+from ._alifestd_check_topological_sensitivity import (
+    _topologically_sensitive_cols,
+)
+
+
+def alifestd_check_topological_sensitivity_polars(
+    phylogeny_df: typing.Union[pl.DataFrame, pl.LazyFrame],
+) -> typing.List[str]:
+    """Return names of columns present in `phylogeny_df` that may be
+    invalidated by topological operations such as collapsing unifurcations.
+
+    Accepts polars DataFrames and LazyFrames.
+
+    Input dataframe is not mutated by this operation.
+
+    See Also
+    --------
+    alifestd_check_topological_sensitivity :
+        Pandas-based implementation.
+    """
+    if isinstance(phylogeny_df, pl.LazyFrame):
+        columns = phylogeny_df.collect_schema().names()
+    else:
+        columns = phylogeny_df.columns
+    return [
+        col for col in columns if col in _topologically_sensitive_cols
+    ]

--- a/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
+++ b/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
@@ -121,8 +121,11 @@ def alifestd_coarsen_mask(
     """
 
     alifestd_warn_topological_sensitivity(
-        phylogeny_df, "alifestd_coarsen_mask",
-        insert=False, delete=True, update=True,
+        phylogeny_df,
+        "alifestd_coarsen_mask",
+        insert=False,
+        delete=True,
+        update=True,
     )
 
     if not mutate:

--- a/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
+++ b/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
@@ -4,14 +4,14 @@ import numpy as np
 import pandas as pd
 
 from ._alifestd_is_asexual import alifestd_is_asexual
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
-)
 from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_parse_ancestor_ids import alifestd_parse_ancestor_ids
 from ._alifestd_topological_sort import alifestd_topological_sort
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 
 
 def _alifestd_coarsen_mask_asexual(

--- a/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
+++ b/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
@@ -1,10 +1,12 @@
 import typing
-import warnings
 
 import numpy as np
 import pandas as pd
 
 from ._alifestd_is_asexual import alifestd_is_asexual
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_parse_ancestor_ids import alifestd_parse_ancestor_ids
@@ -118,12 +120,9 @@ def alifestd_coarsen_mask(
     value to get transformed phylogeny dataframe.
     """
 
-    if "branch_length" in phylogeny_df or "edge_length" in phylogeny_df:
-        warnings.warn(
-            "alifestd_coarsen_mask does not update branch length columns. "
-            "Use `origin_time` to recalculate branch lengths for coarsened "
-            "phylogeny."
-        )
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df, "alifestd_coarsen_mask"
+    )
 
     if not mutate:
         phylogeny_df = phylogeny_df.copy()

--- a/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
+++ b/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
@@ -121,7 +121,8 @@ def alifestd_coarsen_mask(
     """
 
     alifestd_warn_topological_sensitivity(
-        phylogeny_df, "alifestd_coarsen_mask"
+        phylogeny_df, "alifestd_coarsen_mask",
+        insert=False, delete=True, update=True,
     )
 
     if not mutate:

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
@@ -123,8 +123,11 @@ def alifestd_collapse_unifurcations(
     """
 
     alifestd_warn_topological_sensitivity(
-        phylogeny_df, "alifestd_collapse_unifurcations",
-        insert=False, delete=True, update=True,
+        phylogeny_df,
+        "alifestd_collapse_unifurcations",
+        insert=False,
+        delete=True,
+        update=True,
     )
 
     # special optimized handling for asexual phylogenies

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
@@ -120,13 +120,45 @@ def alifestd_collapse_unifurcations(
         Polars-based implementation.
     """
 
-    if any(
-        col in phylogeny_df
-        for col in ["branch_length", "edge_length", "origin_time_delta"]
-    ):
+    warned_cols = [
+        "ancestor_origin_time",
+        "branch_length",
+        "clade_duration",
+        "clade_duration_ratio_sister",
+        "clade_fblr_growth_children",
+        "clade_fblr_growth_sister",
+        "clade_faithpd",
+        "clade_leafcount_ratio_sister",
+        "clade_logistic_growth_children",
+        "clade_logistic_growth_sister",
+        "clade_nodecount_ratio_sister",
+        "clade_subtended_duration",
+        "clade_subtended_duration_ratio_sister",
+        "edge_length",
+        "is_left_child",
+        "is_right_child",
+        "left_child_id",
+        "max_descendant_origin_time",
+        "node_depth",
+        "num_children",
+        "num_descendants",
+        "num_leaves",
+        "num_leaves_sibling",
+        "num_preceding_leaves",
+        "origin_time_delta",
+        "ot_mrca_id",
+        "ot_mrca_time_of",
+        "ot_mrca_time_since",
+        "right_child_id",
+        "sister_id",
+    ]
+    present_warned = [col for col in warned_cols if col in phylogeny_df]
+    if present_warned:
         warnings.warn(
-            "alifestd_collapse_unifurcations does not update branch length "
-            "columns. Use `origin_time` to recalculate branch lengths for "
+            "alifestd_collapse_unifurcations does not update topology-"
+            "dependent columns, which may be invalidated: "
+            f"{present_warned}. "
+            "Use `origin_time` to recalculate branch lengths for "
             "collapsed phylogeny."
         )
 

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
@@ -123,7 +123,8 @@ def alifestd_collapse_unifurcations(
     """
 
     alifestd_warn_topological_sensitivity(
-        phylogeny_df, "alifestd_collapse_unifurcations"
+        phylogeny_df, "alifestd_collapse_unifurcations",
+        insert=False, delete=True, update=True,
     )
 
     # special optimized handling for asexual phylogenies

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
@@ -3,15 +3,13 @@ from collections import Counter
 import logging
 import os
 import typing
+
 import joinem
 from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import numpy as np
 import pandas as pd
 
 from ._alifestd_assign_contiguous_ids import alifestd_assign_contiguous_ids
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
-)
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_asexual import alifestd_is_asexual
 from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
@@ -19,6 +17,9 @@ from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_parse_ancestor_ids import alifestd_parse_ancestor_ids
 from ._alifestd_topological_sort import alifestd_topological_sort
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
@@ -3,14 +3,15 @@ from collections import Counter
 import logging
 import os
 import typing
-import warnings
-
 import joinem
 from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import numpy as np
 import pandas as pd
 
 from ._alifestd_assign_contiguous_ids import alifestd_assign_contiguous_ids
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_asexual import alifestd_is_asexual
 from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
@@ -120,47 +121,9 @@ def alifestd_collapse_unifurcations(
         Polars-based implementation.
     """
 
-    warned_cols = [
-        "ancestor_origin_time",
-        "branch_length",
-        "clade_duration",
-        "clade_duration_ratio_sister",
-        "clade_fblr_growth_children",
-        "clade_fblr_growth_sister",
-        "clade_faithpd",
-        "clade_leafcount_ratio_sister",
-        "clade_logistic_growth_children",
-        "clade_logistic_growth_sister",
-        "clade_nodecount_ratio_sister",
-        "clade_subtended_duration",
-        "clade_subtended_duration_ratio_sister",
-        "edge_length",
-        "is_left_child",
-        "is_right_child",
-        "left_child_id",
-        "max_descendant_origin_time",
-        "node_depth",
-        "num_children",
-        "num_descendants",
-        "num_leaves",
-        "num_leaves_sibling",
-        "num_preceding_leaves",
-        "origin_time_delta",
-        "ot_mrca_id",
-        "ot_mrca_time_of",
-        "ot_mrca_time_since",
-        "right_child_id",
-        "sister_id",
-    ]
-    present_warned = [col for col in warned_cols if col in phylogeny_df]
-    if present_warned:
-        warnings.warn(
-            "alifestd_collapse_unifurcations does not update topology-"
-            "dependent columns, which may be invalidated: "
-            f"{present_warned}. "
-            "Use `origin_time` to recalculate branch lengths for "
-            "collapsed phylogeny."
-        )
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df, "alifestd_collapse_unifurcations"
+    )
 
     # special optimized handling for asexual phylogenies
     if alifestd_is_asexual(phylogeny_df):

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -42,8 +42,11 @@ def alifestd_collapse_unifurcations_polars(
     schema_names = phylogeny_df.lazy().collect_schema().names()
 
     alifestd_warn_topological_sensitivity_polars(
-        phylogeny_df, "alifestd_collapse_unifurcations_polars",
-        insert=False, delete=True, update=True,
+        phylogeny_df,
+        "alifestd_collapse_unifurcations_polars",
+        insert=False,
+        delete=True,
+        update=True,
     )
 
     if "ancestor_list" in schema_names:

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -1,14 +1,15 @@
 import argparse
 import logging
 import os
-import warnings
-
 import joinem
 from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import polars as pl
 
 from ._alifestd_assign_contiguous_ids_polars import (
     alifestd_assign_contiguous_ids_polars,
+)
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
 )
 from ._alifestd_collapse_unifurcations import _collapse_unifurcations
 from ._alifestd_has_contiguous_ids_polars import (
@@ -39,47 +40,9 @@ def alifestd_collapse_unifurcations_polars(
     """
     schema_names = phylogeny_df.lazy().collect_schema().names()
 
-    warned_cols = [
-        "ancestor_origin_time",
-        "branch_length",
-        "clade_duration",
-        "clade_duration_ratio_sister",
-        "clade_fblr_growth_children",
-        "clade_fblr_growth_sister",
-        "clade_faithpd",
-        "clade_leafcount_ratio_sister",
-        "clade_logistic_growth_children",
-        "clade_logistic_growth_sister",
-        "clade_nodecount_ratio_sister",
-        "clade_subtended_duration",
-        "clade_subtended_duration_ratio_sister",
-        "edge_length",
-        "is_left_child",
-        "is_right_child",
-        "left_child_id",
-        "max_descendant_origin_time",
-        "node_depth",
-        "num_children",
-        "num_descendants",
-        "num_leaves",
-        "num_leaves_sibling",
-        "num_preceding_leaves",
-        "origin_time_delta",
-        "ot_mrca_id",
-        "ot_mrca_time_of",
-        "ot_mrca_time_since",
-        "right_child_id",
-        "sister_id",
-    ]
-    present_warned = [col for col in warned_cols if col in schema_names]
-    if present_warned:
-        warnings.warn(
-            "alifestd_collapse_unifurcations does not update topology-"
-            "dependent columns, which may be invalidated: "
-            f"{present_warned}. "
-            "Use `origin_time` to recalculate branch lengths for "
-            "collapsed phylogeny."
-        )
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df, "alifestd_collapse_unifurcations_polars"
+    )
 
     if "ancestor_list" in schema_names:
         raise NotImplementedError

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -42,7 +42,8 @@ def alifestd_collapse_unifurcations_polars(
     schema_names = phylogeny_df.lazy().collect_schema().names()
 
     alifestd_warn_topological_sensitivity_polars(
-        phylogeny_df, "alifestd_collapse_unifurcations_polars"
+        phylogeny_df, "alifestd_collapse_unifurcations_polars",
+        insert=False, delete=True, update=True,
     )
 
     if "ancestor_list" in schema_names:

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -39,13 +39,45 @@ def alifestd_collapse_unifurcations_polars(
     """
     schema_names = phylogeny_df.lazy().collect_schema().names()
 
-    if any(
-        col in schema_names
-        for col in ("branch_length", "edge_length", "origin_time_delta")
-    ):
+    warned_cols = [
+        "ancestor_origin_time",
+        "branch_length",
+        "clade_duration",
+        "clade_duration_ratio_sister",
+        "clade_fblr_growth_children",
+        "clade_fblr_growth_sister",
+        "clade_faithpd",
+        "clade_leafcount_ratio_sister",
+        "clade_logistic_growth_children",
+        "clade_logistic_growth_sister",
+        "clade_nodecount_ratio_sister",
+        "clade_subtended_duration",
+        "clade_subtended_duration_ratio_sister",
+        "edge_length",
+        "is_left_child",
+        "is_right_child",
+        "left_child_id",
+        "max_descendant_origin_time",
+        "node_depth",
+        "num_children",
+        "num_descendants",
+        "num_leaves",
+        "num_leaves_sibling",
+        "num_preceding_leaves",
+        "origin_time_delta",
+        "ot_mrca_id",
+        "ot_mrca_time_of",
+        "ot_mrca_time_since",
+        "right_child_id",
+        "sister_id",
+    ]
+    present_warned = [col for col in warned_cols if col in schema_names]
+    if present_warned:
         warnings.warn(
-            "alifestd_collapse_unifurcations does not update branch length "
-            "columns. Use `origin_time` to recalculate branch lengths for "
+            "alifestd_collapse_unifurcations does not update topology-"
+            "dependent columns, which may be invalidated: "
+            f"{present_warned}. "
+            "Use `origin_time` to recalculate branch lengths for "
             "collapsed phylogeny."
         )
 

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+
 import joinem
 from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import polars as pl
@@ -8,15 +9,15 @@ import polars as pl
 from ._alifestd_assign_contiguous_ids_polars import (
     alifestd_assign_contiguous_ids_polars,
 )
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
-)
 from ._alifestd_collapse_unifurcations import _collapse_unifurcations
 from ._alifestd_has_contiguous_ids_polars import (
     alifestd_has_contiguous_ids_polars,
 )
 from ._alifestd_is_topologically_sorted_polars import (
     alifestd_is_topologically_sorted_polars,
+)
+from ._alifestd_warn_topological_sensitivity_polars import (
+    alifestd_warn_topological_sensitivity_polars,
 )
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
@@ -40,7 +41,7 @@ def alifestd_collapse_unifurcations_polars(
     """
     schema_names = phylogeny_df.lazy().collect_schema().names()
 
-    alifestd_warn_topological_sensitivity(
+    alifestd_warn_topological_sensitivity_polars(
         phylogeny_df, "alifestd_collapse_unifurcations_polars"
     )
 

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
@@ -96,9 +96,21 @@ def _create_parser() -> argparse.ArgumentParser:
         ),
         dfcli_version=get_hstrat_version(),
     )
-    add_bool_arg(parser, "insert", default=True)
-    add_bool_arg(parser, "delete", default=True)
-    add_bool_arg(parser, "update", default=True)
+    add_bool_arg(
+        parser, "insert", default=True,
+        help="drop columns sensitive to node insertion (default: True)",
+    )
+    add_bool_arg(
+        parser, "delete", default=True,
+        help="drop columns sensitive to node deletion (default: True)",
+    )
+    add_bool_arg(
+        parser, "update", default=True,
+        help=(
+            "drop columns sensitive to ancestor relationship updates"
+            " (default: True)"
+        ),
+    )
     return parser
 
 

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
@@ -1,0 +1,29 @@
+import typing
+
+import pandas as pd
+
+from ._alifestd_check_topological_sensitivity import (
+    alifestd_check_topological_sensitivity,
+)
+
+
+def alifestd_drop_topological_sensitivity(
+    phylogeny_df: pd.DataFrame,
+    mutate: bool = False,
+) -> pd.DataFrame:
+    """Drop columns from `phylogeny_df` that may be invalidated by
+    topological operations such as collapsing unifurcations.
+
+    Input dataframe is not mutated by this operation unless `mutate` set True.
+    If mutate set True, operation does not occur in place; still use return
+    value to get transformed phylogeny dataframe.
+    """
+    to_drop = alifestd_check_topological_sensitivity(phylogeny_df)
+    if not to_drop:
+        return phylogeny_df
+
+    if not mutate:
+        phylogeny_df = phylogeny_df.copy()
+
+    phylogeny_df.drop(columns=to_drop, inplace=True)
+    return phylogeny_df

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
@@ -51,7 +51,10 @@ def alifestd_drop_topological_sensitivity(
         Polars-based implementation.
     """
     to_drop = alifestd_check_topological_sensitivity(
-        phylogeny_df, insert=insert, delete=delete, update=update,
+        phylogeny_df,
+        insert=insert,
+        delete=delete,
+        update=update,
     )
 
     if not mutate:
@@ -91,21 +94,26 @@ def _create_parser() -> argparse.ArgumentParser:
     parser = _add_parser_base(
         parser=parser,
         dfcli_module=(
-            "hstrat._auxiliary_lib"
-            "._alifestd_drop_topological_sensitivity"
+            "hstrat._auxiliary_lib" "._alifestd_drop_topological_sensitivity"
         ),
         dfcli_version=get_hstrat_version(),
     )
     add_bool_arg(
-        parser, "insert", default=True,
+        parser,
+        "insert",
+        default=True,
         help="drop columns sensitive to node insertion (default: True)",
     )
     add_bool_arg(
-        parser, "delete", default=True,
+        parser,
+        "delete",
+        default=True,
         help="drop columns sensitive to node deletion (default: True)",
     )
     add_bool_arg(
-        parser, "update", default=True,
+        parser,
+        "update",
+        default=True,
         help=(
             "drop columns sensitive to ancestor relationship updates"
             " (default: True)"
@@ -120,8 +128,7 @@ if __name__ == "__main__":
     parser = _create_parser()
     args, __ = parser.parse_known_args()
     with log_context_duration(
-        "hstrat._auxiliary_lib"
-        "._alifestd_drop_topological_sensitivity",
+        "hstrat._auxiliary_lib" "._alifestd_drop_topological_sensitivity",
         logging.info,
     ):
         _run_dataframe_cli(

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
@@ -19,9 +19,26 @@ from ._log_context_duration import log_context_duration
 def alifestd_drop_topological_sensitivity(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
+    *,
+    insert: bool = True,
+    delete: bool = True,
+    update: bool = True,
 ) -> pd.DataFrame:
     """Drop columns from `phylogeny_df` that may be invalidated by
     topological operations such as collapsing unifurcations.
+
+    Parameters
+    ----------
+    phylogeny_df : pandas.DataFrame
+        The phylogeny as a dataframe in alife standard format.
+    mutate : bool, default False
+        Are side effects on the input argument allowed?
+    insert : bool, default True
+        Drop columns sensitive to node insertion.
+    delete : bool, default True
+        Drop columns sensitive to node deletion.
+    update : bool, default True
+        Drop columns sensitive to ancestor relationship updates.
 
     Input dataframe is not mutated by this operation unless `mutate` set True.
     If mutate set True, operation does not occur in place; still use return
@@ -32,7 +49,9 @@ def alifestd_drop_topological_sensitivity(
     alifestd_drop_topological_sensitivity_polars :
         Polars-based implementation.
     """
-    to_drop = alifestd_check_topological_sensitivity(phylogeny_df)
+    to_drop = alifestd_check_topological_sensitivity(
+        phylogeny_df, insert=insert, delete=delete, update=update,
+    )
 
     if not mutate:
         phylogeny_df = phylogeny_df.copy()

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
@@ -6,6 +6,7 @@ import joinem
 from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import pandas as pd
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_check_topological_sensitivity import (
     alifestd_check_topological_sensitivity,
 )
@@ -95,6 +96,9 @@ def _create_parser() -> argparse.ArgumentParser:
         ),
         dfcli_version=get_hstrat_version(),
     )
+    add_bool_arg(parser, "insert", default=True)
+    add_bool_arg(parser, "delete", default=True)
+    add_bool_arg(parser, "update", default=True)
     return parser
 
 
@@ -111,6 +115,11 @@ if __name__ == "__main__":
         _run_dataframe_cli(
             base_parser=parser,
             output_dataframe_op=delegate_polars_implementation()(
-                alifestd_drop_topological_sensitivity,
+                lambda df: alifestd_drop_topological_sensitivity(
+                    df,
+                    insert=args.insert,
+                    delete=args.delete,
+                    update=args.update,
+                ),
             ),
         )

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity.py
@@ -1,10 +1,19 @@
-import typing
+import argparse
+import logging
+import os
 
+import joinem
+from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import pandas as pd
 
 from ._alifestd_check_topological_sensitivity import (
     alifestd_check_topological_sensitivity,
 )
+from ._configure_prod_logging import configure_prod_logging
+from ._delegate_polars_implementation import delegate_polars_implementation
+from ._format_cli_description import format_cli_description
+from ._get_hstrat_version import get_hstrat_version
+from ._log_context_duration import log_context_duration
 
 
 def alifestd_drop_topological_sensitivity(
@@ -17,13 +26,72 @@ def alifestd_drop_topological_sensitivity(
     Input dataframe is not mutated by this operation unless `mutate` set True.
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
+
+    See Also
+    --------
+    alifestd_drop_topological_sensitivity_polars :
+        Polars-based implementation.
     """
     to_drop = alifestd_check_topological_sensitivity(phylogeny_df)
-    if not to_drop:
-        return phylogeny_df
 
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 
     phylogeny_df.drop(columns=to_drop, inplace=True)
     return phylogeny_df
+
+
+_raw_description = f"""\
+{os.path.basename(__file__)} | \
+(hstrat v{get_hstrat_version()}/joinem v{joinem.__version__})
+
+Drop columns that may be invalidated by topological operations.
+
+Data is assumed to be in alife standard format.
+
+Additional Notes
+================
+- Use `--eager-read` if modifying data file inplace.
+
+- This CLI entrypoint is experimental and may be subject to change.
+
+See Also
+========
+hstrat._auxiliary_lib._alifestd_drop_topological_sensitivity_polars :
+    Entrypoint for high-performance Polars-based implementation.
+"""
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        description=format_cli_description(_raw_description),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser = _add_parser_base(
+        parser=parser,
+        dfcli_module=(
+            "hstrat._auxiliary_lib"
+            "._alifestd_drop_topological_sensitivity"
+        ),
+        dfcli_version=get_hstrat_version(),
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    configure_prod_logging()
+
+    parser = _create_parser()
+    args, __ = parser.parse_known_args()
+    with log_context_duration(
+        "hstrat._auxiliary_lib"
+        "._alifestd_drop_topological_sensitivity",
+        logging.info,
+    ):
+        _run_dataframe_cli(
+            base_parser=parser,
+            output_dataframe_op=delegate_polars_implementation()(
+                alifestd_drop_topological_sensitivity,
+            ),
+        )

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
@@ -1,0 +1,23 @@
+import polars as pl
+
+from ._alifestd_check_topological_sensitivity import (
+    alifestd_check_topological_sensitivity,
+)
+
+
+def alifestd_drop_topological_sensitivity_polars(
+    phylogeny_df: pl.DataFrame,
+) -> pl.DataFrame:
+    """Drop columns from `phylogeny_df` that may be invalidated by
+    topological operations such as collapsing unifurcations.
+
+    See Also
+    --------
+    alifestd_drop_topological_sensitivity :
+        Pandas-based implementation.
+    """
+    to_drop = alifestd_check_topological_sensitivity(phylogeny_df)
+    if not to_drop:
+        return phylogeny_df
+
+    return phylogeny_df.drop(to_drop)

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
@@ -83,9 +83,21 @@ def _create_parser() -> argparse.ArgumentParser:
         ),
         dfcli_version=get_hstrat_version(),
     )
-    add_bool_arg(parser, "insert", default=True)
-    add_bool_arg(parser, "delete", default=True)
-    add_bool_arg(parser, "update", default=True)
+    add_bool_arg(
+        parser, "insert", default=True,
+        help="drop columns sensitive to node insertion (default: True)",
+    )
+    add_bool_arg(
+        parser, "delete", default=True,
+        help="drop columns sensitive to node deletion (default: True)",
+    )
+    add_bool_arg(
+        parser, "update", default=True,
+        help=(
+            "drop columns sensitive to ancestor relationship updates"
+            " (default: True)"
+        ),
+    )
     return parser
 
 

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
@@ -1,8 +1,18 @@
+import argparse
+import logging
+import os
+
+import joinem
+from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import polars as pl
 
-from ._alifestd_check_topological_sensitivity import (
-    alifestd_check_topological_sensitivity,
+from ._alifestd_check_topological_sensitivity_polars import (
+    alifestd_check_topological_sensitivity_polars,
 )
+from ._configure_prod_logging import configure_prod_logging
+from ._format_cli_description import format_cli_description
+from ._get_hstrat_version import get_hstrat_version
+from ._log_context_duration import log_context_duration
 
 
 def alifestd_drop_topological_sensitivity_polars(
@@ -16,8 +26,68 @@ def alifestd_drop_topological_sensitivity_polars(
     alifestd_drop_topological_sensitivity :
         Pandas-based implementation.
     """
-    to_drop = alifestd_check_topological_sensitivity(phylogeny_df)
-    if not to_drop:
-        return phylogeny_df
-
+    to_drop = alifestd_check_topological_sensitivity_polars(phylogeny_df)
     return phylogeny_df.drop(to_drop)
+
+
+_raw_description = f"""\
+{os.path.basename(__file__)} | \
+(hstrat v{get_hstrat_version()}/joinem v{joinem.__version__})
+
+Drop columns that may be invalidated by topological operations.
+
+Data is assumed to be in alife standard format.
+
+Additional Notes
+================
+- Use `--eager-read` if modifying data file inplace.
+
+- This CLI entrypoint is experimental and may be subject to change.
+
+See Also
+========
+hstrat._auxiliary_lib._alifestd_drop_topological_sensitivity :
+    CLI entrypoint for Pandas-based implementation.
+"""
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        description=format_cli_description(_raw_description),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser = _add_parser_base(
+        parser=parser,
+        dfcli_module=(
+            "hstrat._auxiliary_lib"
+            "._alifestd_drop_topological_sensitivity_polars"
+        ),
+        dfcli_version=get_hstrat_version(),
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    configure_prod_logging()
+
+    parser = _create_parser()
+    args, __ = parser.parse_known_args()
+
+    try:
+        with log_context_duration(
+            "hstrat._auxiliary_lib"
+            "._alifestd_drop_topological_sensitivity_polars",
+            logging.info,
+        ):
+            _run_dataframe_cli(
+                base_parser=parser,
+                output_dataframe_op=(
+                    alifestd_drop_topological_sensitivity_polars
+                ),
+            )
+    except NotImplementedError as e:
+        logging.error(
+            "- polars op not yet implemented, use pandas op CLI instead",
+        )
+        raise e

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
@@ -43,7 +43,10 @@ def alifestd_drop_topological_sensitivity_polars(
         Pandas-based implementation.
     """
     to_drop = alifestd_check_topological_sensitivity_polars(
-        phylogeny_df, insert=insert, delete=delete, update=update,
+        phylogeny_df,
+        insert=insert,
+        delete=delete,
+        update=update,
     )
     return phylogeny_df.drop(to_drop)
 
@@ -84,15 +87,21 @@ def _create_parser() -> argparse.ArgumentParser:
         dfcli_version=get_hstrat_version(),
     )
     add_bool_arg(
-        parser, "insert", default=True,
+        parser,
+        "insert",
+        default=True,
         help="drop columns sensitive to node insertion (default: True)",
     )
     add_bool_arg(
-        parser, "delete", default=True,
+        parser,
+        "delete",
+        default=True,
         help="drop columns sensitive to node deletion (default: True)",
     )
     add_bool_arg(
-        parser, "update", default=True,
+        parser,
+        "update",
+        default=True,
         help=(
             "drop columns sensitive to ancestor relationship updates"
             " (default: True)"

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
@@ -17,16 +17,33 @@ from ._log_context_duration import log_context_duration
 
 def alifestd_drop_topological_sensitivity_polars(
     phylogeny_df: pl.DataFrame,
+    *,
+    insert: bool = True,
+    delete: bool = True,
+    update: bool = True,
 ) -> pl.DataFrame:
     """Drop columns from `phylogeny_df` that may be invalidated by
     topological operations such as collapsing unifurcations.
+
+    Parameters
+    ----------
+    phylogeny_df : polars.DataFrame
+        The phylogeny as a dataframe in alife standard format.
+    insert : bool, default True
+        Drop columns sensitive to node insertion.
+    delete : bool, default True
+        Drop columns sensitive to node deletion.
+    update : bool, default True
+        Drop columns sensitive to ancestor relationship updates.
 
     See Also
     --------
     alifestd_drop_topological_sensitivity :
         Pandas-based implementation.
     """
-    to_drop = alifestd_check_topological_sensitivity_polars(phylogeny_df)
+    to_drop = alifestd_check_topological_sensitivity_polars(
+        phylogeny_df, insert=insert, delete=delete, update=update,
+    )
     return phylogeny_df.drop(to_drop)
 
 

--- a/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_drop_topological_sensitivity_polars.py
@@ -6,6 +6,7 @@ import joinem
 from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import polars as pl
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_check_topological_sensitivity_polars import (
     alifestd_check_topological_sensitivity_polars,
 )
@@ -82,6 +83,9 @@ def _create_parser() -> argparse.ArgumentParser:
         ),
         dfcli_version=get_hstrat_version(),
     )
+    add_bool_arg(parser, "insert", default=True)
+    add_bool_arg(parser, "delete", default=True)
+    add_bool_arg(parser, "update", default=True)
     return parser
 
 
@@ -100,7 +104,12 @@ if __name__ == "__main__":
             _run_dataframe_cli(
                 base_parser=parser,
                 output_dataframe_op=(
-                    alifestd_drop_topological_sensitivity_polars
+                    lambda df: alifestd_drop_topological_sensitivity_polars(
+                        df,
+                        insert=args.insert,
+                        delete=args.delete,
+                        update=args.update,
+                    )
                 ),
             )
     except NotImplementedError as e:

--- a/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
@@ -2,12 +2,12 @@ import numpy as np
 import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
-)
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_unfurl_lineage_asexual import alifestd_unfurl_lineage_asexual
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._pairwise import pairwise
 
 

--- a/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
@@ -1,9 +1,10 @@
-import warnings
-
 import numpy as np
 import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_unfurl_lineage_asexual import alifestd_unfurl_lineage_asexual
@@ -38,12 +39,9 @@ def alifestd_reroot_at_id_asexual(
         The rerooted phylogeny in alife standard format.
     """
 
-    if "branch_length" in phylogeny_df or "edge_length" in phylogeny_df:
-        warnings.warn(
-            "alifestd_reroot_at_id_asexual does not update branch length "
-            "columns. Use `origin_time` to recalculate branch lengths for "
-            "rerooted phylogeny."
-        )
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df, "alifestd_reroot_at_id_asexual"
+    )
 
     if not mutate:
         phylogeny_df = phylogeny_df.copy()

--- a/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
@@ -40,8 +40,11 @@ def alifestd_reroot_at_id_asexual(
     """
 
     alifestd_warn_topological_sensitivity(
-        phylogeny_df, "alifestd_reroot_at_id_asexual",
-        insert=False, delete=False, update=True,
+        phylogeny_df,
+        "alifestd_reroot_at_id_asexual",
+        insert=False,
+        delete=False,
+        update=True,
     )
 
     if not mutate:

--- a/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
@@ -40,7 +40,8 @@ def alifestd_reroot_at_id_asexual(
     """
 
     alifestd_warn_topological_sensitivity(
-        phylogeny_df, "alifestd_reroot_at_id_asexual"
+        phylogeny_df, "alifestd_reroot_at_id_asexual",
+        insert=False, delete=False, update=True,
     )
 
     if not mutate:

--- a/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
+++ b/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
@@ -164,7 +164,8 @@ def alifestd_splay_polytomies(
     """
 
     alifestd_warn_topological_sensitivity(
-        phylogeny_df, "alifestd_splay_polytomies"
+        phylogeny_df, "alifestd_splay_polytomies",
+        insert=True, delete=False, update=True,
     )
 
     if not mutate:

--- a/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
+++ b/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
@@ -164,8 +164,11 @@ def alifestd_splay_polytomies(
     """
 
     alifestd_warn_topological_sensitivity(
-        phylogeny_df, "alifestd_splay_polytomies",
-        insert=True, delete=False, update=True,
+        phylogeny_df,
+        "alifestd_splay_polytomies",
+        insert=True,
+        delete=False,
+        update=True,
     )
 
     if not mutate:

--- a/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
+++ b/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
@@ -5,11 +5,11 @@ import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_asexual import alifestd_is_asexual
+from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_warn_topological_sensitivity import (
     alifestd_warn_topological_sensitivity,
 )
-from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._jit import jit
 from ._jit_numba_dict_t import jit_numba_dict_t
 from ._jit_numpy_int64_t import jit_numpy_int64_t

--- a/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
+++ b/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
@@ -1,11 +1,13 @@
 import itertools as it
-import warnings
 
 import numpy as np
 import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_asexual import alifestd_is_asexual
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._jit import jit
@@ -161,12 +163,9 @@ def alifestd_splay_polytomies(
     value to get transformed phylogeny dataframe.
     """
 
-    if "branch_length" in phylogeny_df or "edge_length" in phylogeny_df:
-        warnings.warn(
-            "alifestd_splay_polytomies does not update branch length columns. "
-            "Use `origin_time` to recalculate branch lengths for collapsed "
-            "phylogeny."
-        )
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df, "alifestd_splay_polytomies"
+    )
 
     if not mutate:
         phylogeny_df = phylogeny_df.copy()

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -1,14 +1,21 @@
+import typing
 import warnings
 
 import pandas as pd
+import polars as pl
 
 from ._alifestd_check_topological_sensitivity import (
     alifestd_check_topological_sensitivity,
 )
+from ._alifestd_check_topological_sensitivity_polars import (
+    alifestd_check_topological_sensitivity_polars,
+)
 
 
 def _alifestd_warn_topological_sensitivity(
-    phylogeny_df,
+    phylogeny_df: typing.Union[
+        pd.DataFrame, pl.DataFrame, pl.LazyFrame,
+    ],
     caller: str,
     *,
     insert: bool,
@@ -20,18 +27,7 @@ def _alifestd_warn_topological_sensitivity(
 
     Accepts both pandas and polars DataFrames/LazyFrames.
     """
-    try:
-        import polars as pl
-
-        is_polars = isinstance(phylogeny_df, (pl.DataFrame, pl.LazyFrame))
-    except ImportError:
-        is_polars = False
-
-    if is_polars:
-        from ._alifestd_check_topological_sensitivity_polars import (
-            alifestd_check_topological_sensitivity_polars,
-        )
-
+    if isinstance(phylogeny_df, (pl.DataFrame, pl.LazyFrame)):
         present_warned = alifestd_check_topological_sensitivity_polars(
             phylogeny_df, insert=insert, delete=delete, update=update,
         )

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -7,15 +7,59 @@ from ._alifestd_check_topological_sensitivity import (
 )
 
 
-def _format_ops(insert: bool, delete: bool, update: bool) -> str:
-    ops = []
-    if insert:
-        ops.append("insert")
-    if delete:
-        ops.append("delete")
-    if update:
-        ops.append("update")
-    return "/".join(ops)
+def _alifestd_warn_topological_sensitivity(
+    phylogeny_df,
+    caller: str,
+    *,
+    insert: bool,
+    delete: bool,
+    update: bool,
+) -> None:
+    """Private helper: emit a warning if `phylogeny_df` contains columns
+    that may be invalidated by topological operations.
+
+    Accepts both pandas and polars DataFrames/LazyFrames.
+    """
+    try:
+        import polars as pl
+
+        is_polars = isinstance(phylogeny_df, (pl.DataFrame, pl.LazyFrame))
+    except ImportError:
+        is_polars = False
+
+    if is_polars:
+        from ._alifestd_check_topological_sensitivity_polars import (
+            alifestd_check_topological_sensitivity_polars,
+        )
+
+        present_warned = alifestd_check_topological_sensitivity_polars(
+            phylogeny_df, insert=insert, delete=delete, update=update,
+        )
+        drop_fn = "alifestd_drop_topological_sensitivity_polars"
+    else:
+        present_warned = alifestd_check_topological_sensitivity(
+            phylogeny_df, insert=insert, delete=delete, update=update,
+        )
+        drop_fn = "alifestd_drop_topological_sensitivity"
+
+    if present_warned:
+        ops = "/".join(
+            name
+            for flag, name in [
+                (insert, "insert"),
+                (delete, "delete"),
+                (update, "update"),
+            ]
+            if flag
+        )
+        warnings.warn(
+            f"{caller} performs {ops} operations that do not update "
+            f"topology-dependent columns, which may be invalidated: "
+            f"{present_warned}. "
+            "Use `origin_time` to recalculate branch lengths for "
+            f"collapsed phylogeny. To silence this warning, use "
+            f"{drop_fn}."
+        )
 
 
 def alifestd_warn_topological_sensitivity(
@@ -49,16 +93,7 @@ def alifestd_warn_topological_sensitivity(
     alifestd_warn_topological_sensitivity_polars :
         Polars-based implementation.
     """
-    present_warned = alifestd_check_topological_sensitivity(
-        phylogeny_df, insert=insert, delete=delete, update=update,
+    _alifestd_warn_topological_sensitivity(
+        phylogeny_df, caller,
+        insert=insert, delete=delete, update=update,
     )
-    if present_warned:
-        ops = _format_ops(insert, delete, update)
-        warnings.warn(
-            f"{caller} performs {ops} operations that do not update "
-            f"topology-dependent columns, which may be invalidated: "
-            f"{present_warned}. "
-            "Use `origin_time` to recalculate branch lengths for "
-            "collapsed phylogeny. To silence this warning, use "
-            "alifestd_drop_topological_sensitivity."
-        )

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -1,0 +1,32 @@
+import typing
+import warnings
+
+from ._alifestd_check_topological_sensitivity import (
+    alifestd_check_topological_sensitivity,
+)
+
+
+def alifestd_warn_topological_sensitivity(
+    phylogeny_df: typing.Any,
+    caller: str,
+) -> None:
+    """Emit a warning if `phylogeny_df` contains columns that may be
+    invalidated by topological operations.
+
+    Parameters
+    ----------
+    phylogeny_df
+        A pandas or polars DataFrame.
+    caller : str
+        Name of the calling function, included in the warning message.
+
+    Input dataframe is not mutated by this operation.
+    """
+    present_warned = alifestd_check_topological_sensitivity(phylogeny_df)
+    if present_warned:
+        warnings.warn(
+            f"{caller} does not update topology-dependent columns, "
+            f"which may be invalidated: {present_warned}. "
+            "Use `origin_time` to recalculate branch lengths for "
+            "collapsed phylogeny."
+        )

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -71,6 +71,9 @@ def alifestd_warn_topological_sensitivity(
         Polars-based implementation.
     """
     _alifestd_warn_topological_sensitivity(
-        phylogeny_df.columns, caller,
-        insert=insert, delete=delete, update=update,
+        phylogeny_df.columns,
+        caller,
+        insert=insert,
+        delete=delete,
+        update=update,
     )

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -3,22 +3,20 @@ import warnings
 
 import pandas as pd
 
-from ._alifestd_check_topological_sensitivity import _get_sensitive_cols
+from ._alifestd_check_topological_sensitivity import (
+    alifestd_check_topological_sensitivity,
+)
 
 
 def _alifestd_warn_topological_sensitivity(
-    columns: typing.Sequence[str],
+    invalidated: typing.List[str],
     caller: str,
     *,
     insert: bool,
     delete: bool,
     update: bool,
 ) -> None:
-    """Private helper: emit a warning if any column names may be
-    invalidated by topological operations."""
-    sensitive = _get_sensitive_cols(insert, delete, update)
-    invalidated = [col for col in columns if col in sensitive]
-
+    """Private helper: emit a warning listing invalidated columns."""
     if invalidated:
         ops = "/".join(
             name
@@ -71,7 +69,12 @@ def alifestd_warn_topological_sensitivity(
         Polars-based implementation.
     """
     _alifestd_warn_topological_sensitivity(
-        phylogeny_df.columns,
+        alifestd_check_topological_sensitivity(
+            phylogeny_df,
+            insert=insert,
+            delete=delete,
+            update=update,
+        ),
         caller,
         insert=insert,
         delete=delete,

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -2,31 +2,21 @@ import typing
 import warnings
 
 import pandas as pd
-import polars as pl
 
 from ._alifestd_check_topological_sensitivity import _get_sensitive_cols
 
 
 def _alifestd_warn_topological_sensitivity(
-    phylogeny_df: typing.Union[
-        pd.DataFrame, pl.DataFrame, pl.LazyFrame,
-    ],
+    columns: typing.Sequence[str],
     caller: str,
     *,
     insert: bool,
     delete: bool,
     update: bool,
 ) -> None:
-    """Private helper: emit a warning if `phylogeny_df` contains columns
-    that may be invalidated by topological operations.
-
-    Accepts both pandas and polars DataFrames/LazyFrames.
-    """
+    """Private helper: emit a warning if any column names may be
+    invalidated by topological operations."""
     sensitive = _get_sensitive_cols(insert, delete, update)
-    if isinstance(phylogeny_df, (pl.DataFrame, pl.LazyFrame)):
-        columns = phylogeny_df.lazy().collect_schema().names()
-    else:
-        columns = phylogeny_df.columns
     invalidated = [col for col in columns if col in sensitive]
 
     if invalidated:
@@ -81,6 +71,6 @@ def alifestd_warn_topological_sensitivity(
         Polars-based implementation.
     """
     _alifestd_warn_topological_sensitivity(
-        phylogeny_df, caller,
+        phylogeny_df.columns, caller,
         insert=insert, delete=delete, update=update,
     )

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -7,9 +7,24 @@ from ._alifestd_check_topological_sensitivity import (
 )
 
 
+def _format_ops(insert: bool, delete: bool, update: bool) -> str:
+    ops = []
+    if insert:
+        ops.append("insert")
+    if delete:
+        ops.append("delete")
+    if update:
+        ops.append("update")
+    return "/".join(ops)
+
+
 def alifestd_warn_topological_sensitivity(
     phylogeny_df: pd.DataFrame,
     caller: str,
+    *,
+    insert: bool,
+    delete: bool,
+    update: bool,
 ) -> None:
     """Emit a warning if `phylogeny_df` contains columns that may be
     invalidated by topological operations.
@@ -20,6 +35,12 @@ def alifestd_warn_topological_sensitivity(
         The phylogeny as a dataframe in alife standard format.
     caller : str
         Name of the calling function, included in the warning message.
+    insert : bool
+        Whether the operation inserts new nodes.
+    delete : bool
+        Whether the operation deletes nodes.
+    update : bool
+        Whether the operation updates ancestor relationships.
 
     Input dataframe is not mutated by this operation.
 
@@ -28,11 +49,15 @@ def alifestd_warn_topological_sensitivity(
     alifestd_warn_topological_sensitivity_polars :
         Polars-based implementation.
     """
-    present_warned = alifestd_check_topological_sensitivity(phylogeny_df)
+    present_warned = alifestd_check_topological_sensitivity(
+        phylogeny_df, insert=insert, delete=delete, update=update,
+    )
     if present_warned:
+        ops = _format_ops(insert, delete, update)
         warnings.warn(
-            f"{caller} does not update topology-dependent columns, "
-            f"which may be invalidated: {present_warned}. "
+            f"{caller} performs {ops} operations that do not update "
+            f"topology-dependent columns, which may be invalidated: "
+            f"{present_warned}. "
             "Use `origin_time` to recalculate branch lengths for "
             "collapsed phylogeny. To silence this warning, use "
             "alifestd_drop_topological_sensitivity."

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
@@ -2,6 +2,9 @@ import typing
 
 import polars as pl
 
+from ._alifestd_check_topological_sensitivity_polars import (
+    alifestd_check_topological_sensitivity_polars,
+)
 from ._alifestd_warn_topological_sensitivity import (
     _alifestd_warn_topological_sensitivity,
 )
@@ -39,7 +42,12 @@ def alifestd_warn_topological_sensitivity_polars(
         Pandas-based implementation.
     """
     _alifestd_warn_topological_sensitivity(
-        phylogeny_df.lazy().collect_schema().names(),
+        alifestd_check_topological_sensitivity_polars(
+            phylogeny_df,
+            insert=insert,
+            delete=delete,
+            update=update,
+        ),
         caller,
         insert=insert,
         delete=delete,

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
@@ -38,7 +38,8 @@ def alifestd_warn_topological_sensitivity_polars(
     alifestd_warn_topological_sensitivity :
         Pandas-based implementation.
     """
+    columns = phylogeny_df.lazy().collect_schema().names()
     _alifestd_warn_topological_sensitivity(
-        phylogeny_df, caller,
+        columns, caller,
         insert=insert, delete=delete, update=update,
     )

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
@@ -6,11 +6,16 @@ import polars as pl
 from ._alifestd_check_topological_sensitivity_polars import (
     alifestd_check_topological_sensitivity_polars,
 )
+from ._alifestd_warn_topological_sensitivity import _format_ops
 
 
 def alifestd_warn_topological_sensitivity_polars(
     phylogeny_df: typing.Union[pl.DataFrame, pl.LazyFrame],
     caller: str,
+    *,
+    insert: bool,
+    delete: bool,
+    update: bool,
 ) -> None:
     """Emit a warning if `phylogeny_df` contains columns that may be
     invalidated by topological operations.
@@ -21,6 +26,12 @@ def alifestd_warn_topological_sensitivity_polars(
         The phylogeny as a dataframe in alife standard format.
     caller : str
         Name of the calling function, included in the warning message.
+    insert : bool
+        Whether the operation inserts new nodes.
+    delete : bool
+        Whether the operation deletes nodes.
+    update : bool
+        Whether the operation updates ancestor relationships.
 
     Input dataframe is not mutated by this operation.
 
@@ -30,12 +41,14 @@ def alifestd_warn_topological_sensitivity_polars(
         Pandas-based implementation.
     """
     present_warned = alifestd_check_topological_sensitivity_polars(
-        phylogeny_df,
+        phylogeny_df, insert=insert, delete=delete, update=update,
     )
     if present_warned:
+        ops = _format_ops(insert, delete, update)
         warnings.warn(
-            f"{caller} does not update topology-dependent columns, "
-            f"which may be invalidated: {present_warned}. "
+            f"{caller} performs {ops} operations that do not update "
+            f"topology-dependent columns, which may be invalidated: "
+            f"{present_warned}. "
             "Use `origin_time` to recalculate branch lengths for "
             "collapsed phylogeny. To silence this warning, use "
             "alifestd_drop_topological_sensitivity_polars."

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
@@ -1,12 +1,10 @@
 import typing
-import warnings
 
 import polars as pl
 
-from ._alifestd_check_topological_sensitivity_polars import (
-    alifestd_check_topological_sensitivity_polars,
+from ._alifestd_warn_topological_sensitivity import (
+    _alifestd_warn_topological_sensitivity,
 )
-from ._alifestd_warn_topological_sensitivity import _format_ops
 
 
 def alifestd_warn_topological_sensitivity_polars(
@@ -40,16 +38,7 @@ def alifestd_warn_topological_sensitivity_polars(
     alifestd_warn_topological_sensitivity :
         Pandas-based implementation.
     """
-    present_warned = alifestd_check_topological_sensitivity_polars(
-        phylogeny_df, insert=insert, delete=delete, update=update,
+    _alifestd_warn_topological_sensitivity(
+        phylogeny_df, caller,
+        insert=insert, delete=delete, update=update,
     )
-    if present_warned:
-        ops = _format_ops(insert, delete, update)
-        warnings.warn(
-            f"{caller} performs {ops} operations that do not update "
-            f"topology-dependent columns, which may be invalidated: "
-            f"{present_warned}. "
-            "Use `origin_time` to recalculate branch lengths for "
-            "collapsed phylogeny. To silence this warning, use "
-            "alifestd_drop_topological_sensitivity_polars."
-        )

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
@@ -1,14 +1,15 @@
+import typing
 import warnings
 
-import pandas as pd
+import polars as pl
 
-from ._alifestd_check_topological_sensitivity import (
-    alifestd_check_topological_sensitivity,
+from ._alifestd_check_topological_sensitivity_polars import (
+    alifestd_check_topological_sensitivity_polars,
 )
 
 
-def alifestd_warn_topological_sensitivity(
-    phylogeny_df: pd.DataFrame,
+def alifestd_warn_topological_sensitivity_polars(
+    phylogeny_df: typing.Union[pl.DataFrame, pl.LazyFrame],
     caller: str,
 ) -> None:
     """Emit a warning if `phylogeny_df` contains columns that may be
@@ -16,7 +17,7 @@ def alifestd_warn_topological_sensitivity(
 
     Parameters
     ----------
-    phylogeny_df : pandas.DataFrame
+    phylogeny_df : polars.DataFrame or polars.LazyFrame
         The phylogeny as a dataframe in alife standard format.
     caller : str
         Name of the calling function, included in the warning message.
@@ -25,15 +26,17 @@ def alifestd_warn_topological_sensitivity(
 
     See Also
     --------
-    alifestd_warn_topological_sensitivity_polars :
-        Polars-based implementation.
+    alifestd_warn_topological_sensitivity :
+        Pandas-based implementation.
     """
-    present_warned = alifestd_check_topological_sensitivity(phylogeny_df)
+    present_warned = alifestd_check_topological_sensitivity_polars(
+        phylogeny_df,
+    )
     if present_warned:
         warnings.warn(
             f"{caller} does not update topology-dependent columns, "
             f"which may be invalidated: {present_warned}. "
             "Use `origin_time` to recalculate branch lengths for "
             "collapsed phylogeny. To silence this warning, use "
-            "alifestd_drop_topological_sensitivity."
+            "alifestd_drop_topological_sensitivity_polars."
         )

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity_polars.py
@@ -38,8 +38,10 @@ def alifestd_warn_topological_sensitivity_polars(
     alifestd_warn_topological_sensitivity :
         Pandas-based implementation.
     """
-    columns = phylogeny_df.lazy().collect_schema().names()
     _alifestd_warn_topological_sensitivity(
-        columns, caller,
-        insert=insert, delete=delete, update=update,
+        phylogeny_df.lazy().collect_schema().names(),
+        caller,
+        insert=insert,
+        delete=delete,
+        update=update,
     )

--- a/tests/test_hstrat/test_auxiliary_lib/test_add_bool_arg.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_add_bool_arg.py
@@ -1,0 +1,57 @@
+import argparse
+
+from hstrat._auxiliary_lib._add_bool_arg import add_bool_arg
+
+
+def test_default_false():
+    parser = argparse.ArgumentParser()
+    add_bool_arg(parser, "foo")
+    args = parser.parse_args([])
+    assert args.foo is False
+
+
+def test_default_true():
+    parser = argparse.ArgumentParser()
+    add_bool_arg(parser, "foo", default=True)
+    args = parser.parse_args([])
+    assert args.foo is True
+
+
+def test_flag_true():
+    parser = argparse.ArgumentParser()
+    add_bool_arg(parser, "foo")
+    args = parser.parse_args(["--foo"])
+    assert args.foo is True
+
+
+def test_flag_false():
+    parser = argparse.ArgumentParser()
+    add_bool_arg(parser, "foo", default=True)
+    args = parser.parse_args(["--no-foo"])
+    assert args.foo is False
+
+
+def test_hyphenated_name():
+    parser = argparse.ArgumentParser()
+    add_bool_arg(parser, "my-flag", default=False)
+    args = parser.parse_args(["--my-flag"])
+    assert args.my_flag is True
+    args = parser.parse_args(["--no-my-flag"])
+    assert args.my_flag is False
+
+
+def test_multiple_flags():
+    parser = argparse.ArgumentParser()
+    add_bool_arg(parser, "insert", default=True)
+    add_bool_arg(parser, "delete", default=True)
+    add_bool_arg(parser, "update", default=True)
+
+    args = parser.parse_args(["--no-insert"])
+    assert args.insert is False
+    assert args.delete is True
+    assert args.update is True
+
+    args = parser.parse_args(["--no-insert", "--no-update"])
+    assert args.insert is False
+    assert args.delete is True
+    assert args.update is False

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
@@ -8,6 +8,7 @@ from hstrat._auxiliary_lib import (
     alifestd_warn_topological_sensitivity,
 )
 from hstrat._auxiliary_lib._alifestd_check_topological_sensitivity import (
+    _insert_insensitive_cols,
     _topologically_sensitive_cols,
 )
 
@@ -24,7 +25,9 @@ def base_df():
 
 
 def test_none_present(base_df):
-    result = alifestd_check_topological_sensitivity(base_df)
+    result = alifestd_check_topological_sensitivity(
+        base_df, insert=True, delete=True, update=True,
+    )
     assert result == []
 
 
@@ -32,7 +35,9 @@ def test_none_present(base_df):
 def test_single_sensitive_col(base_df, col):
     df = base_df.copy()
     df[col] = 0
-    result = alifestd_check_topological_sensitivity(df)
+    result = alifestd_check_topological_sensitivity(
+        df, insert=True, delete=True, update=True,
+    )
     assert result == [col]
 
 
@@ -41,7 +46,9 @@ def test_multiple_sensitive_cols(base_df):
     df["branch_length"] = 0
     df["node_depth"] = 0
     df["sister_id"] = 0
-    result = alifestd_check_topological_sensitivity(df)
+    result = alifestd_check_topological_sensitivity(
+        df, insert=True, delete=True, update=True,
+    )
     assert set(result) == {"branch_length", "node_depth", "sister_id"}
 
 
@@ -49,7 +56,9 @@ def test_non_sensitive_cols_ignored(base_df):
     df = base_df.copy()
     df["taxon_label"] = "x"
     df["extant"] = True
-    result = alifestd_check_topological_sensitivity(df)
+    result = alifestd_check_topological_sensitivity(
+        df, insert=True, delete=True, update=True,
+    )
     assert result == []
 
 
@@ -59,7 +68,9 @@ def test_mixed_sensitive_and_non_sensitive(base_df):
     df["branch_length"] = 0.0
     df["extant"] = True
     df["ancestor_origin_time"] = 0
-    result = alifestd_check_topological_sensitivity(df)
+    result = alifestd_check_topological_sensitivity(
+        df, insert=True, delete=True, update=True,
+    )
     assert set(result) == {"ancestor_origin_time", "branch_length"}
 
 
@@ -67,7 +78,9 @@ def test_no_mutation(base_df):
     df = base_df.copy()
     df["branch_length"] = 0
     original = df.copy()
-    alifestd_check_topological_sensitivity(df)
+    alifestd_check_topological_sensitivity(
+        df, insert=True, delete=True, update=True,
+    )
     pd.testing.assert_frame_equal(df, original)
 
 
@@ -78,7 +91,9 @@ def test_empty_dataframe():
             "ancestor_id": pd.Series([], dtype=int),
         }
     )
-    assert alifestd_check_topological_sensitivity(df) == []
+    assert alifestd_check_topological_sensitivity(
+        df, insert=True, delete=True, update=True,
+    ) == []
 
 
 def test_empty_dataframe_with_sensitive():
@@ -88,9 +103,62 @@ def test_empty_dataframe_with_sensitive():
             "branch_length": pd.Series([], dtype=float),
         }
     )
-    assert alifestd_check_topological_sensitivity(df) == [
-        "branch_length"
-    ]
+    assert alifestd_check_topological_sensitivity(
+        df, insert=True, delete=True, update=True,
+    ) == ["branch_length"]
+
+
+@pytest.mark.parametrize("col", sorted(_insert_insensitive_cols))
+def test_insert_only_excludes_insert_insensitive(base_df, col):
+    df = base_df.copy()
+    df[col] = 0
+    result = alifestd_check_topological_sensitivity(
+        df, insert=True, delete=False, update=False,
+    )
+    assert col not in result
+
+
+@pytest.mark.parametrize(
+    "col",
+    sorted(_topologically_sensitive_cols - _insert_insensitive_cols),
+)
+def test_insert_only_includes_insert_sensitive(base_df, col):
+    df = base_df.copy()
+    df[col] = 0
+    result = alifestd_check_topological_sensitivity(
+        df, insert=True, delete=False, update=False,
+    )
+    assert result == [col]
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_delete_includes_all(base_df, col):
+    df = base_df.copy()
+    df[col] = 0
+    result = alifestd_check_topological_sensitivity(
+        df, insert=False, delete=True, update=False,
+    )
+    assert result == [col]
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_update_includes_all(base_df, col):
+    df = base_df.copy()
+    df[col] = 0
+    result = alifestd_check_topological_sensitivity(
+        df, insert=False, delete=False, update=True,
+    )
+    assert result == [col]
+
+
+def test_no_ops_returns_empty(base_df):
+    df = base_df.copy()
+    for col in sorted(_topologically_sensitive_cols):
+        df[col] = 0
+    result = alifestd_check_topological_sensitivity(
+        df, insert=False, delete=False, update=False,
+    )
+    assert result == []
 
 
 def test_warn_topological_sensitivity_warns(base_df):
@@ -98,10 +166,14 @@ def test_warn_topological_sensitivity_warns(base_df):
     df["branch_length"] = 0
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        alifestd_warn_topological_sensitivity(df, "test_caller")
+        alifestd_warn_topological_sensitivity(
+            df, "test_caller",
+            insert=False, delete=True, update=True,
+        )
         assert len(w) == 1
         assert "test_caller" in str(w[0].message)
         assert "branch_length" in str(w[0].message)
+        assert "delete/update" in str(w[0].message)
         assert "alifestd_drop_topological_sensitivity" in str(
             w[0].message,
         )
@@ -110,5 +182,21 @@ def test_warn_topological_sensitivity_warns(base_df):
 def test_warn_topological_sensitivity_silent(base_df):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        alifestd_warn_topological_sensitivity(base_df, "test_caller")
+        alifestd_warn_topological_sensitivity(
+            base_df, "test_caller",
+            insert=True, delete=True, update=True,
+        )
         assert len(w) == 0
+
+
+def test_warn_topological_sensitivity_ops_in_message(base_df):
+    df = base_df.copy()
+    df["sister_id"] = 0
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_warn_topological_sensitivity(
+            df, "test_caller",
+            insert=True, delete=False, update=True,
+        )
+        assert len(w) == 1
+        assert "insert/update" in str(w[0].message)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
@@ -1,0 +1,237 @@
+import pandas as pd
+import polars as pl
+import pytest
+
+from hstrat._auxiliary_lib import alifestd_check_topological_sensitivity
+
+
+@pytest.fixture
+def base_df_pandas():
+    return pd.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_id": [0, 0, 1],
+            "origin_time": [0, 1, 2],
+        }
+    )
+
+
+@pytest.fixture
+def base_df_polars():
+    return pl.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_id": [0, 0, 1],
+            "origin_time": [0, 1, 2],
+        }
+    )
+
+
+class TestNonePresent:
+    def test_pandas(self, base_df_pandas):
+        result = alifestd_check_topological_sensitivity(base_df_pandas)
+        assert result == []
+
+    def test_polars(self, base_df_polars):
+        result = alifestd_check_topological_sensitivity(base_df_polars)
+        assert result == []
+
+
+class TestSingleSensitiveCol:
+    @pytest.mark.parametrize(
+        "col",
+        [
+            "ancestor_origin_time",
+            "branch_length",
+            "edge_length",
+            "origin_time_delta",
+            "node_depth",
+            "num_children",
+            "num_descendants",
+            "num_leaves",
+            "sister_id",
+            "left_child_id",
+            "right_child_id",
+            "is_left_child",
+            "is_right_child",
+            "max_descendant_origin_time",
+            "clade_duration",
+            "clade_subtended_duration",
+            "clade_faithpd",
+            "clade_duration_ratio_sister",
+            "clade_subtended_duration_ratio_sister",
+            "clade_leafcount_ratio_sister",
+            "clade_nodecount_ratio_sister",
+            "clade_fblr_growth_children",
+            "clade_fblr_growth_sister",
+            "clade_logistic_growth_children",
+            "clade_logistic_growth_sister",
+            "num_leaves_sibling",
+            "num_preceding_leaves",
+            "ot_mrca_id",
+            "ot_mrca_time_of",
+            "ot_mrca_time_since",
+        ],
+    )
+    def test_pandas(self, base_df_pandas, col):
+        df = base_df_pandas.copy()
+        df[col] = 0
+        result = alifestd_check_topological_sensitivity(df)
+        assert result == [col]
+
+    @pytest.mark.parametrize(
+        "col",
+        [
+            "ancestor_origin_time",
+            "branch_length",
+            "edge_length",
+            "origin_time_delta",
+            "node_depth",
+            "num_children",
+        ],
+    )
+    def test_polars(self, base_df_polars, col):
+        df = base_df_polars.with_columns(pl.lit(0).alias(col))
+        result = alifestd_check_topological_sensitivity(df)
+        assert result == [col]
+
+
+class TestMultipleSensitiveCols:
+    def test_pandas(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        df["branch_length"] = 0
+        df["node_depth"] = 0
+        df["sister_id"] = 0
+        result = alifestd_check_topological_sensitivity(df)
+        assert result == ["branch_length", "node_depth", "sister_id"]
+
+    def test_polars(self, base_df_polars):
+        df = base_df_polars.with_columns(
+            pl.lit(0).alias("branch_length"),
+            pl.lit(0).alias("node_depth"),
+            pl.lit(0).alias("sister_id"),
+        )
+        result = alifestd_check_topological_sensitivity(df)
+        assert result == ["branch_length", "node_depth", "sister_id"]
+
+
+class TestNonSensitiveColsIgnored:
+    def test_pandas(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        df["taxon_label"] = "x"
+        df["extant"] = True
+        result = alifestd_check_topological_sensitivity(df)
+        assert result == []
+
+    def test_polars(self, base_df_polars):
+        df = base_df_polars.with_columns(
+            pl.lit("x").alias("taxon_label"),
+            pl.lit(True).alias("extant"),
+        )
+        result = alifestd_check_topological_sensitivity(df)
+        assert result == []
+
+
+class TestMixedSensitiveAndNonSensitive:
+    def test_pandas(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        df["taxon_label"] = "x"
+        df["branch_length"] = 0.0
+        df["extant"] = True
+        df["ancestor_origin_time"] = 0
+        result = alifestd_check_topological_sensitivity(df)
+        assert result == ["ancestor_origin_time", "branch_length"]
+
+    def test_polars(self, base_df_polars):
+        df = base_df_polars.with_columns(
+            pl.lit("x").alias("taxon_label"),
+            pl.lit(0.0).alias("branch_length"),
+            pl.lit(True).alias("extant"),
+            pl.lit(0).alias("ancestor_origin_time"),
+        )
+        result = alifestd_check_topological_sensitivity(df)
+        assert result == ["ancestor_origin_time", "branch_length"]
+
+
+class TestNoMutation:
+    def test_pandas(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        df["branch_length"] = 0
+        original = df.copy()
+        alifestd_check_topological_sensitivity(df)
+        pd.testing.assert_frame_equal(df, original)
+
+    def test_polars(self, base_df_polars):
+        df = base_df_polars.with_columns(
+            pl.lit(0).alias("branch_length"),
+        )
+        original = df.clone()
+        alifestd_check_topological_sensitivity(df)
+        assert df.equals(original)
+
+
+class TestEmptyDataFrame:
+    def test_pandas(self):
+        df = pd.DataFrame(
+            {"id": pd.Series([], dtype=int), "ancestor_id": pd.Series([], dtype=int)}
+        )
+        assert alifestd_check_topological_sensitivity(df) == []
+
+    def test_pandas_with_sensitive(self):
+        df = pd.DataFrame(
+            {
+                "id": pd.Series([], dtype=int),
+                "branch_length": pd.Series([], dtype=float),
+            }
+        )
+        assert alifestd_check_topological_sensitivity(df) == [
+            "branch_length"
+        ]
+
+    def test_polars(self):
+        df = pl.DataFrame(
+            {"id": pl.Series([], dtype=pl.Int64)}
+        )
+        assert alifestd_check_topological_sensitivity(df) == []
+
+    def test_polars_with_sensitive(self):
+        df = pl.DataFrame(
+            {
+                "id": pl.Series([], dtype=pl.Int64),
+                "branch_length": pl.Series([], dtype=pl.Float64),
+            }
+        )
+        assert alifestd_check_topological_sensitivity(df) == [
+            "branch_length"
+        ]
+
+
+class TestReturnOrder:
+    """Verify that returned columns follow the canonical order defined in
+    _topologically_sensitive_cols, not the DataFrame column order."""
+
+    def test_pandas(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        # add in reverse alphabetical order
+        df["sister_id"] = 0
+        df["branch_length"] = 0
+        df["ancestor_origin_time"] = 0
+        result = alifestd_check_topological_sensitivity(df)
+        assert result == [
+            "ancestor_origin_time",
+            "branch_length",
+            "sister_id",
+        ]
+
+    def test_polars(self, base_df_polars):
+        df = base_df_polars.with_columns(
+            pl.lit(0).alias("sister_id"),
+            pl.lit(0).alias("branch_length"),
+            pl.lit(0).alias("ancestor_origin_time"),
+        )
+        result = alifestd_check_topological_sensitivity(df)
+        assert result == [
+            "ancestor_origin_time",
+            "branch_length",
+            "sister_id",
+        ]

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
@@ -8,8 +8,8 @@ from hstrat._auxiliary_lib import (
     alifestd_warn_topological_sensitivity,
 )
 from hstrat._auxiliary_lib._alifestd_check_topological_sensitivity import (
-    _insert_insensitive_cols,
     _topologically_sensitive_cols,
+    _update_only_sensitive_cols,
 )
 
 
@@ -108,8 +108,8 @@ def test_empty_dataframe_with_sensitive():
     ) == ["branch_length"]
 
 
-@pytest.mark.parametrize("col", sorted(_insert_insensitive_cols))
-def test_insert_only_excludes_insert_insensitive(base_df, col):
+@pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
+def test_insert_only_excludes_update_only(base_df, col):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
@@ -120,9 +120,9 @@ def test_insert_only_excludes_insert_insensitive(base_df, col):
 
 @pytest.mark.parametrize(
     "col",
-    sorted(_topologically_sensitive_cols - _insert_insensitive_cols),
+    sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_includes_insert_sensitive(base_df, col):
+def test_insert_only_includes_structure_sensitive(base_df, col):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
@@ -131,8 +131,21 @@ def test_insert_only_includes_insert_sensitive(base_df, col):
     assert result == [col]
 
 
-@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_delete_includes_all(base_df, col):
+@pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
+def test_delete_only_excludes_update_only(base_df, col):
+    df = base_df.copy()
+    df[col] = 0
+    result = alifestd_check_topological_sensitivity(
+        df, insert=False, delete=True, update=False,
+    )
+    assert col not in result
+
+
+@pytest.mark.parametrize(
+    "col",
+    sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
+)
+def test_delete_only_includes_structure_sensitive(base_df, col):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
@@ -26,7 +26,10 @@ def base_df():
 
 def test_none_present(base_df: pd.DataFrame):
     result = alifestd_check_topological_sensitivity(
-        base_df, insert=True, delete=True, update=True,
+        base_df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert result == []
 
@@ -36,7 +39,10 @@ def test_single_sensitive_col(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert result == [col]
 
@@ -47,7 +53,10 @@ def test_multiple_sensitive_cols(base_df: pd.DataFrame):
     df["node_depth"] = 0
     df["sister_id"] = 0
     result = alifestd_check_topological_sensitivity(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert set(result) == {"branch_length", "node_depth", "sister_id"}
 
@@ -57,7 +66,10 @@ def test_non_sensitive_cols_ignored(base_df: pd.DataFrame):
     df["taxon_label"] = "x"
     df["extant"] = True
     result = alifestd_check_topological_sensitivity(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert result == []
 
@@ -69,7 +81,10 @@ def test_mixed_sensitive_and_non_sensitive(base_df: pd.DataFrame):
     df["extant"] = True
     df["ancestor_origin_time"] = 0
     result = alifestd_check_topological_sensitivity(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert set(result) == {"ancestor_origin_time", "branch_length"}
 
@@ -79,7 +94,10 @@ def test_no_mutation(base_df: pd.DataFrame):
     df["branch_length"] = 0
     original = df.copy()
     alifestd_check_topological_sensitivity(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     pd.testing.assert_frame_equal(df, original)
 
@@ -91,9 +109,15 @@ def test_empty_dataframe():
             "ancestor_id": pd.Series([], dtype=int),
         }
     )
-    assert alifestd_check_topological_sensitivity(
-        df, insert=True, delete=True, update=True,
-    ) == []
+    assert (
+        alifestd_check_topological_sensitivity(
+            df,
+            insert=True,
+            delete=True,
+            update=True,
+        )
+        == []
+    )
 
 
 def test_empty_dataframe_with_sensitive():
@@ -104,7 +128,10 @@ def test_empty_dataframe_with_sensitive():
         }
     )
     assert alifestd_check_topological_sensitivity(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     ) == ["branch_length"]
 
 
@@ -113,7 +140,10 @@ def test_insert_only_excludes_update_only(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
-        df, insert=True, delete=False, update=False,
+        df,
+        insert=True,
+        delete=False,
+        update=False,
     )
     assert col not in result
 
@@ -122,11 +152,16 @@ def test_insert_only_excludes_update_only(base_df: pd.DataFrame, col: str):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_includes_structure_sensitive(base_df: pd.DataFrame, col: str):
+def test_insert_only_includes_structure_sensitive(
+    base_df: pd.DataFrame, col: str
+):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
-        df, insert=True, delete=False, update=False,
+        df,
+        insert=True,
+        delete=False,
+        update=False,
     )
     assert result == [col]
 
@@ -136,7 +171,10 @@ def test_delete_only_excludes_update_only(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
-        df, insert=False, delete=True, update=False,
+        df,
+        insert=False,
+        delete=True,
+        update=False,
     )
     assert col not in result
 
@@ -145,11 +183,16 @@ def test_delete_only_excludes_update_only(base_df: pd.DataFrame, col: str):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_delete_only_includes_structure_sensitive(base_df: pd.DataFrame, col: str):
+def test_delete_only_includes_structure_sensitive(
+    base_df: pd.DataFrame, col: str
+):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
-        df, insert=False, delete=True, update=False,
+        df,
+        insert=False,
+        delete=True,
+        update=False,
     )
     assert result == [col]
 
@@ -159,7 +202,10 @@ def test_update_includes_all(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
-        df, insert=False, delete=False, update=True,
+        df,
+        insert=False,
+        delete=False,
+        update=True,
     )
     assert result == [col]
 
@@ -169,7 +215,10 @@ def test_no_ops_returns_empty(base_df: pd.DataFrame):
     for col in sorted(_topologically_sensitive_cols):
         df[col] = 0
     result = alifestd_check_topological_sensitivity(
-        df, insert=False, delete=False, update=False,
+        df,
+        insert=False,
+        delete=False,
+        update=False,
     )
     assert result == []
 
@@ -180,8 +229,11 @@ def test_warn_topological_sensitivity_warns(base_df: pd.DataFrame):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity(
-            df, "test_caller",
-            insert=False, delete=True, update=True,
+            df,
+            "test_caller",
+            insert=False,
+            delete=True,
+            update=True,
         )
         assert len(w) == 1
         assert "test_caller" in str(w[0].message)
@@ -196,8 +248,11 @@ def test_warn_topological_sensitivity_silent(base_df: pd.DataFrame):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity(
-            base_df, "test_caller",
-            insert=True, delete=True, update=True,
+            base_df,
+            "test_caller",
+            insert=True,
+            delete=True,
+            update=True,
         )
         assert len(w) == 0
 
@@ -208,8 +263,11 @@ def test_warn_topological_sensitivity_ops_in_message(base_df: pd.DataFrame):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity(
-            df, "test_caller",
-            insert=True, delete=False, update=True,
+            df,
+            "test_caller",
+            insert=True,
+            delete=False,
+            update=True,
         )
         assert len(w) == 1
         assert "insert/update" in str(w[0].message)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
@@ -1,12 +1,19 @@
+import warnings
+
 import pandas as pd
-import polars as pl
 import pytest
 
-from hstrat._auxiliary_lib import alifestd_check_topological_sensitivity
+from hstrat._auxiliary_lib import (
+    alifestd_check_topological_sensitivity,
+    alifestd_warn_topological_sensitivity,
+)
+from hstrat._auxiliary_lib._alifestd_check_topological_sensitivity import (
+    _topologically_sensitive_cols,
+)
 
 
 @pytest.fixture
-def base_df_pandas():
+def base_df():
     return pd.DataFrame(
         {
             "id": [0, 1, 2],
@@ -16,222 +23,92 @@ def base_df_pandas():
     )
 
 
-@pytest.fixture
-def base_df_polars():
-    return pl.DataFrame(
+def test_none_present(base_df):
+    result = alifestd_check_topological_sensitivity(base_df)
+    assert result == []
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_single_sensitive_col(base_df, col):
+    df = base_df.copy()
+    df[col] = 0
+    result = alifestd_check_topological_sensitivity(df)
+    assert result == [col]
+
+
+def test_multiple_sensitive_cols(base_df):
+    df = base_df.copy()
+    df["branch_length"] = 0
+    df["node_depth"] = 0
+    df["sister_id"] = 0
+    result = alifestd_check_topological_sensitivity(df)
+    assert set(result) == {"branch_length", "node_depth", "sister_id"}
+
+
+def test_non_sensitive_cols_ignored(base_df):
+    df = base_df.copy()
+    df["taxon_label"] = "x"
+    df["extant"] = True
+    result = alifestd_check_topological_sensitivity(df)
+    assert result == []
+
+
+def test_mixed_sensitive_and_non_sensitive(base_df):
+    df = base_df.copy()
+    df["taxon_label"] = "x"
+    df["branch_length"] = 0.0
+    df["extant"] = True
+    df["ancestor_origin_time"] = 0
+    result = alifestd_check_topological_sensitivity(df)
+    assert set(result) == {"ancestor_origin_time", "branch_length"}
+
+
+def test_no_mutation(base_df):
+    df = base_df.copy()
+    df["branch_length"] = 0
+    original = df.copy()
+    alifestd_check_topological_sensitivity(df)
+    pd.testing.assert_frame_equal(df, original)
+
+
+def test_empty_dataframe():
+    df = pd.DataFrame(
         {
-            "id": [0, 1, 2],
-            "ancestor_id": [0, 0, 1],
-            "origin_time": [0, 1, 2],
+            "id": pd.Series([], dtype=int),
+            "ancestor_id": pd.Series([], dtype=int),
         }
     )
+    assert alifestd_check_topological_sensitivity(df) == []
 
 
-class TestNonePresent:
-    def test_pandas(self, base_df_pandas):
-        result = alifestd_check_topological_sensitivity(base_df_pandas)
-        assert result == []
-
-    def test_polars(self, base_df_polars):
-        result = alifestd_check_topological_sensitivity(base_df_polars)
-        assert result == []
-
-
-class TestSingleSensitiveCol:
-    @pytest.mark.parametrize(
-        "col",
-        [
-            "ancestor_origin_time",
-            "branch_length",
-            "edge_length",
-            "origin_time_delta",
-            "node_depth",
-            "num_children",
-            "num_descendants",
-            "num_leaves",
-            "sister_id",
-            "left_child_id",
-            "right_child_id",
-            "is_left_child",
-            "is_right_child",
-            "max_descendant_origin_time",
-            "clade_duration",
-            "clade_subtended_duration",
-            "clade_faithpd",
-            "clade_duration_ratio_sister",
-            "clade_subtended_duration_ratio_sister",
-            "clade_leafcount_ratio_sister",
-            "clade_nodecount_ratio_sister",
-            "clade_fblr_growth_children",
-            "clade_fblr_growth_sister",
-            "clade_logistic_growth_children",
-            "clade_logistic_growth_sister",
-            "num_leaves_sibling",
-            "num_preceding_leaves",
-            "ot_mrca_id",
-            "ot_mrca_time_of",
-            "ot_mrca_time_since",
-        ],
+def test_empty_dataframe_with_sensitive():
+    df = pd.DataFrame(
+        {
+            "id": pd.Series([], dtype=int),
+            "branch_length": pd.Series([], dtype=float),
+        }
     )
-    def test_pandas(self, base_df_pandas, col):
-        df = base_df_pandas.copy()
-        df[col] = 0
-        result = alifestd_check_topological_sensitivity(df)
-        assert result == [col]
-
-    @pytest.mark.parametrize(
-        "col",
-        [
-            "ancestor_origin_time",
-            "branch_length",
-            "edge_length",
-            "origin_time_delta",
-            "node_depth",
-            "num_children",
-        ],
-    )
-    def test_polars(self, base_df_polars, col):
-        df = base_df_polars.with_columns(pl.lit(0).alias(col))
-        result = alifestd_check_topological_sensitivity(df)
-        assert result == [col]
+    assert alifestd_check_topological_sensitivity(df) == [
+        "branch_length"
+    ]
 
 
-class TestMultipleSensitiveCols:
-    def test_pandas(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        df["branch_length"] = 0
-        df["node_depth"] = 0
-        df["sister_id"] = 0
-        result = alifestd_check_topological_sensitivity(df)
-        assert result == ["branch_length", "node_depth", "sister_id"]
-
-    def test_polars(self, base_df_polars):
-        df = base_df_polars.with_columns(
-            pl.lit(0).alias("branch_length"),
-            pl.lit(0).alias("node_depth"),
-            pl.lit(0).alias("sister_id"),
+def test_warn_topological_sensitivity_warns(base_df):
+    df = base_df.copy()
+    df["branch_length"] = 0
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_warn_topological_sensitivity(df, "test_caller")
+        assert len(w) == 1
+        assert "test_caller" in str(w[0].message)
+        assert "branch_length" in str(w[0].message)
+        assert "alifestd_drop_topological_sensitivity" in str(
+            w[0].message,
         )
-        result = alifestd_check_topological_sensitivity(df)
-        assert result == ["branch_length", "node_depth", "sister_id"]
 
 
-class TestNonSensitiveColsIgnored:
-    def test_pandas(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        df["taxon_label"] = "x"
-        df["extant"] = True
-        result = alifestd_check_topological_sensitivity(df)
-        assert result == []
-
-    def test_polars(self, base_df_polars):
-        df = base_df_polars.with_columns(
-            pl.lit("x").alias("taxon_label"),
-            pl.lit(True).alias("extant"),
-        )
-        result = alifestd_check_topological_sensitivity(df)
-        assert result == []
-
-
-class TestMixedSensitiveAndNonSensitive:
-    def test_pandas(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        df["taxon_label"] = "x"
-        df["branch_length"] = 0.0
-        df["extant"] = True
-        df["ancestor_origin_time"] = 0
-        result = alifestd_check_topological_sensitivity(df)
-        assert result == ["ancestor_origin_time", "branch_length"]
-
-    def test_polars(self, base_df_polars):
-        df = base_df_polars.with_columns(
-            pl.lit("x").alias("taxon_label"),
-            pl.lit(0.0).alias("branch_length"),
-            pl.lit(True).alias("extant"),
-            pl.lit(0).alias("ancestor_origin_time"),
-        )
-        result = alifestd_check_topological_sensitivity(df)
-        assert result == ["ancestor_origin_time", "branch_length"]
-
-
-class TestNoMutation:
-    def test_pandas(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        df["branch_length"] = 0
-        original = df.copy()
-        alifestd_check_topological_sensitivity(df)
-        pd.testing.assert_frame_equal(df, original)
-
-    def test_polars(self, base_df_polars):
-        df = base_df_polars.with_columns(
-            pl.lit(0).alias("branch_length"),
-        )
-        original = df.clone()
-        alifestd_check_topological_sensitivity(df)
-        assert df.equals(original)
-
-
-class TestEmptyDataFrame:
-    def test_pandas(self):
-        df = pd.DataFrame(
-            {"id": pd.Series([], dtype=int), "ancestor_id": pd.Series([], dtype=int)}
-        )
-        assert alifestd_check_topological_sensitivity(df) == []
-
-    def test_pandas_with_sensitive(self):
-        df = pd.DataFrame(
-            {
-                "id": pd.Series([], dtype=int),
-                "branch_length": pd.Series([], dtype=float),
-            }
-        )
-        assert alifestd_check_topological_sensitivity(df) == [
-            "branch_length"
-        ]
-
-    def test_polars(self):
-        df = pl.DataFrame(
-            {"id": pl.Series([], dtype=pl.Int64)}
-        )
-        assert alifestd_check_topological_sensitivity(df) == []
-
-    def test_polars_with_sensitive(self):
-        df = pl.DataFrame(
-            {
-                "id": pl.Series([], dtype=pl.Int64),
-                "branch_length": pl.Series([], dtype=pl.Float64),
-            }
-        )
-        assert alifestd_check_topological_sensitivity(df) == [
-            "branch_length"
-        ]
-
-
-class TestReturnOrder:
-    """Verify that returned columns follow the canonical order defined in
-    _topologically_sensitive_cols, not the DataFrame column order."""
-
-    def test_pandas(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        # add in reverse alphabetical order
-        df["sister_id"] = 0
-        df["branch_length"] = 0
-        df["ancestor_origin_time"] = 0
-        result = alifestd_check_topological_sensitivity(df)
-        assert result == [
-            "ancestor_origin_time",
-            "branch_length",
-            "sister_id",
-        ]
-
-    def test_polars(self, base_df_polars):
-        df = base_df_polars.with_columns(
-            pl.lit(0).alias("sister_id"),
-            pl.lit(0).alias("branch_length"),
-            pl.lit(0).alias("ancestor_origin_time"),
-        )
-        result = alifestd_check_topological_sensitivity(df)
-        assert result == [
-            "ancestor_origin_time",
-            "branch_length",
-            "sister_id",
-        ]
+def test_warn_topological_sensitivity_silent(base_df):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_warn_topological_sensitivity(base_df, "test_caller")
+        assert len(w) == 0

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity.py
@@ -24,7 +24,7 @@ def base_df():
     )
 
 
-def test_none_present(base_df):
+def test_none_present(base_df: pd.DataFrame):
     result = alifestd_check_topological_sensitivity(
         base_df, insert=True, delete=True, update=True,
     )
@@ -32,7 +32,7 @@ def test_none_present(base_df):
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_single_sensitive_col(base_df, col):
+def test_single_sensitive_col(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
@@ -41,7 +41,7 @@ def test_single_sensitive_col(base_df, col):
     assert result == [col]
 
 
-def test_multiple_sensitive_cols(base_df):
+def test_multiple_sensitive_cols(base_df: pd.DataFrame):
     df = base_df.copy()
     df["branch_length"] = 0
     df["node_depth"] = 0
@@ -52,7 +52,7 @@ def test_multiple_sensitive_cols(base_df):
     assert set(result) == {"branch_length", "node_depth", "sister_id"}
 
 
-def test_non_sensitive_cols_ignored(base_df):
+def test_non_sensitive_cols_ignored(base_df: pd.DataFrame):
     df = base_df.copy()
     df["taxon_label"] = "x"
     df["extant"] = True
@@ -62,7 +62,7 @@ def test_non_sensitive_cols_ignored(base_df):
     assert result == []
 
 
-def test_mixed_sensitive_and_non_sensitive(base_df):
+def test_mixed_sensitive_and_non_sensitive(base_df: pd.DataFrame):
     df = base_df.copy()
     df["taxon_label"] = "x"
     df["branch_length"] = 0.0
@@ -74,7 +74,7 @@ def test_mixed_sensitive_and_non_sensitive(base_df):
     assert set(result) == {"ancestor_origin_time", "branch_length"}
 
 
-def test_no_mutation(base_df):
+def test_no_mutation(base_df: pd.DataFrame):
     df = base_df.copy()
     df["branch_length"] = 0
     original = df.copy()
@@ -109,7 +109,7 @@ def test_empty_dataframe_with_sensitive():
 
 
 @pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
-def test_insert_only_excludes_update_only(base_df, col):
+def test_insert_only_excludes_update_only(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
@@ -122,7 +122,7 @@ def test_insert_only_excludes_update_only(base_df, col):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_includes_structure_sensitive(base_df, col):
+def test_insert_only_includes_structure_sensitive(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
@@ -132,7 +132,7 @@ def test_insert_only_includes_structure_sensitive(base_df, col):
 
 
 @pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
-def test_delete_only_excludes_update_only(base_df, col):
+def test_delete_only_excludes_update_only(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
@@ -145,7 +145,7 @@ def test_delete_only_excludes_update_only(base_df, col):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_delete_only_includes_structure_sensitive(base_df, col):
+def test_delete_only_includes_structure_sensitive(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
@@ -155,7 +155,7 @@ def test_delete_only_includes_structure_sensitive(base_df, col):
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_update_includes_all(base_df, col):
+def test_update_includes_all(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_check_topological_sensitivity(
@@ -164,7 +164,7 @@ def test_update_includes_all(base_df, col):
     assert result == [col]
 
 
-def test_no_ops_returns_empty(base_df):
+def test_no_ops_returns_empty(base_df: pd.DataFrame):
     df = base_df.copy()
     for col in sorted(_topologically_sensitive_cols):
         df[col] = 0
@@ -174,7 +174,7 @@ def test_no_ops_returns_empty(base_df):
     assert result == []
 
 
-def test_warn_topological_sensitivity_warns(base_df):
+def test_warn_topological_sensitivity_warns(base_df: pd.DataFrame):
     df = base_df.copy()
     df["branch_length"] = 0
     with warnings.catch_warnings(record=True) as w:
@@ -192,7 +192,7 @@ def test_warn_topological_sensitivity_warns(base_df):
         )
 
 
-def test_warn_topological_sensitivity_silent(base_df):
+def test_warn_topological_sensitivity_silent(base_df: pd.DataFrame):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity(
@@ -202,7 +202,7 @@ def test_warn_topological_sensitivity_silent(base_df):
         assert len(w) == 0
 
 
-def test_warn_topological_sensitivity_ops_in_message(base_df):
+def test_warn_topological_sensitivity_ops_in_message(base_df: pd.DataFrame):
     df = base_df.copy()
     df["sister_id"] = 0
     with warnings.catch_warnings(record=True) as w:

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity_polars.py
@@ -8,6 +8,7 @@ from hstrat._auxiliary_lib import (
     alifestd_warn_topological_sensitivity_polars,
 )
 from hstrat._auxiliary_lib._alifestd_check_topological_sensitivity import (
+    _insert_insensitive_cols,
     _topologically_sensitive_cols,
 )
 
@@ -24,14 +25,18 @@ def base_df():
 
 
 def test_none_present(base_df):
-    result = alifestd_check_topological_sensitivity_polars(base_df)
+    result = alifestd_check_topological_sensitivity_polars(
+        base_df, insert=True, delete=True, update=True,
+    )
     assert result == []
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
 def test_single_sensitive_col(base_df, col):
     df = base_df.with_columns(pl.lit(0).alias(col))
-    result = alifestd_check_topological_sensitivity_polars(df)
+    result = alifestd_check_topological_sensitivity_polars(
+        df, insert=True, delete=True, update=True,
+    )
     assert result == [col]
 
 
@@ -41,7 +46,9 @@ def test_multiple_sensitive_cols(base_df):
         pl.lit(0).alias("node_depth"),
         pl.lit(0).alias("sister_id"),
     )
-    result = alifestd_check_topological_sensitivity_polars(df)
+    result = alifestd_check_topological_sensitivity_polars(
+        df, insert=True, delete=True, update=True,
+    )
     assert set(result) == {"branch_length", "node_depth", "sister_id"}
 
 
@@ -50,20 +57,26 @@ def test_non_sensitive_cols_ignored(base_df):
         pl.lit("x").alias("taxon_label"),
         pl.lit(True).alias("extant"),
     )
-    result = alifestd_check_topological_sensitivity_polars(df)
+    result = alifestd_check_topological_sensitivity_polars(
+        df, insert=True, delete=True, update=True,
+    )
     assert result == []
 
 
 def test_no_mutation(base_df):
     df = base_df.with_columns(pl.lit(0).alias("branch_length"))
     original = df.clone()
-    alifestd_check_topological_sensitivity_polars(df)
+    alifestd_check_topological_sensitivity_polars(
+        df, insert=True, delete=True, update=True,
+    )
     assert df.equals(original)
 
 
 def test_empty_dataframe():
     df = pl.DataFrame({"id": pl.Series([], dtype=pl.Int64)})
-    assert alifestd_check_topological_sensitivity_polars(df) == []
+    assert alifestd_check_topological_sensitivity_polars(
+        df, insert=True, delete=True, update=True,
+    ) == []
 
 
 def test_empty_dataframe_with_sensitive():
@@ -73,23 +86,84 @@ def test_empty_dataframe_with_sensitive():
             "branch_length": pl.Series([], dtype=pl.Float64),
         }
     )
-    assert alifestd_check_topological_sensitivity_polars(df) == [
-        "branch_length"
-    ]
+    assert alifestd_check_topological_sensitivity_polars(
+        df, insert=True, delete=True, update=True,
+    ) == ["branch_length"]
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
 def test_lazyframe(base_df, col):
     df = base_df.with_columns(pl.lit(0).alias(col))
     lazy = df.lazy()
-    result = alifestd_check_topological_sensitivity_polars(lazy)
+    result = alifestd_check_topological_sensitivity_polars(
+        lazy, insert=True, delete=True, update=True,
+    )
     assert result == [col]
 
 
 def test_lazyframe_none_present(base_df):
     lazy = base_df.lazy()
-    result = alifestd_check_topological_sensitivity_polars(lazy)
+    result = alifestd_check_topological_sensitivity_polars(
+        lazy, insert=True, delete=True, update=True,
+    )
     assert result == []
+
+
+@pytest.mark.parametrize("col", sorted(_insert_insensitive_cols))
+def test_insert_only_excludes_insert_insensitive(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_check_topological_sensitivity_polars(
+        df, insert=True, delete=False, update=False,
+    )
+    assert col not in result
+
+
+@pytest.mark.parametrize(
+    "col",
+    sorted(_topologically_sensitive_cols - _insert_insensitive_cols),
+)
+def test_insert_only_includes_insert_sensitive(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_check_topological_sensitivity_polars(
+        df, insert=True, delete=False, update=False,
+    )
+    assert result == [col]
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_delete_includes_all(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_check_topological_sensitivity_polars(
+        df, insert=False, delete=True, update=False,
+    )
+    assert result == [col]
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_update_includes_all(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_check_topological_sensitivity_polars(
+        df, insert=False, delete=False, update=True,
+    )
+    assert result == [col]
+
+
+def test_no_ops_returns_empty(base_df):
+    cols = [pl.lit(0).alias(col) for col in _topologically_sensitive_cols]
+    df = base_df.with_columns(cols)
+    result = alifestd_check_topological_sensitivity_polars(
+        df, insert=False, delete=False, update=False,
+    )
+    assert result == []
+
+
+@pytest.mark.parametrize("col", sorted(_insert_insensitive_cols))
+def test_insert_only_lazyframe_excludes(base_df, col):
+    lazy = base_df.with_columns(pl.lit(0).alias(col)).lazy()
+    result = alifestd_check_topological_sensitivity_polars(
+        lazy, insert=True, delete=False, update=False,
+    )
+    assert col not in result
 
 
 def test_warn_topological_sensitivity_polars_warns(base_df):
@@ -98,10 +172,12 @@ def test_warn_topological_sensitivity_polars_warns(base_df):
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity_polars(
             df, "test_caller",
+            insert=False, delete=True, update=True,
         )
         assert len(w) == 1
         assert "test_caller" in str(w[0].message)
         assert "branch_length" in str(w[0].message)
+        assert "delete/update" in str(w[0].message)
         assert "alifestd_drop_topological_sensitivity_polars" in str(
             w[0].message,
         )
@@ -112,6 +188,7 @@ def test_warn_topological_sensitivity_polars_silent(base_df):
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity_polars(
             base_df, "test_caller",
+            insert=True, delete=True, update=True,
         )
         assert len(w) == 0
 
@@ -124,6 +201,19 @@ def test_warn_topological_sensitivity_polars_lazyframe(base_df):
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity_polars(
             lazy, "test_caller",
+            insert=False, delete=True, update=True,
         )
         assert len(w) == 1
         assert "edge_length" in str(w[0].message)
+
+
+def test_warn_topological_sensitivity_polars_ops_in_message(base_df):
+    df = base_df.with_columns(pl.lit(0).alias("sister_id"))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_warn_topological_sensitivity_polars(
+            df, "test_caller",
+            insert=True, delete=False, update=False,
+        )
+        assert len(w) == 1
+        assert "insert" in str(w[0].message)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity_polars.py
@@ -26,7 +26,10 @@ def base_df():
 
 def test_none_present(base_df: pl.DataFrame):
     result = alifestd_check_topological_sensitivity_polars(
-        base_df, insert=True, delete=True, update=True,
+        base_df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert result == []
 
@@ -35,7 +38,10 @@ def test_none_present(base_df: pl.DataFrame):
 def test_single_sensitive_col(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert result == [col]
 
@@ -47,7 +53,10 @@ def test_multiple_sensitive_cols(base_df: pl.DataFrame):
         pl.lit(0).alias("sister_id"),
     )
     result = alifestd_check_topological_sensitivity_polars(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert set(result) == {"branch_length", "node_depth", "sister_id"}
 
@@ -58,7 +67,10 @@ def test_non_sensitive_cols_ignored(base_df: pl.DataFrame):
         pl.lit(True).alias("extant"),
     )
     result = alifestd_check_topological_sensitivity_polars(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert result == []
 
@@ -67,16 +79,25 @@ def test_no_mutation(base_df: pl.DataFrame):
     df = base_df.with_columns(pl.lit(0).alias("branch_length"))
     original = df.clone()
     alifestd_check_topological_sensitivity_polars(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert df.equals(original)
 
 
 def test_empty_dataframe():
     df = pl.DataFrame({"id": pl.Series([], dtype=pl.Int64)})
-    assert alifestd_check_topological_sensitivity_polars(
-        df, insert=True, delete=True, update=True,
-    ) == []
+    assert (
+        alifestd_check_topological_sensitivity_polars(
+            df,
+            insert=True,
+            delete=True,
+            update=True,
+        )
+        == []
+    )
 
 
 def test_empty_dataframe_with_sensitive():
@@ -87,7 +108,10 @@ def test_empty_dataframe_with_sensitive():
         }
     )
     assert alifestd_check_topological_sensitivity_polars(
-        df, insert=True, delete=True, update=True,
+        df,
+        insert=True,
+        delete=True,
+        update=True,
     ) == ["branch_length"]
 
 
@@ -96,7 +120,10 @@ def test_lazyframe(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     lazy = df.lazy()
     result = alifestd_check_topological_sensitivity_polars(
-        lazy, insert=True, delete=True, update=True,
+        lazy,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert result == [col]
 
@@ -104,7 +131,10 @@ def test_lazyframe(base_df: pl.DataFrame, col: str):
 def test_lazyframe_none_present(base_df: pl.DataFrame):
     lazy = base_df.lazy()
     result = alifestd_check_topological_sensitivity_polars(
-        lazy, insert=True, delete=True, update=True,
+        lazy,
+        insert=True,
+        delete=True,
+        update=True,
     )
     assert result == []
 
@@ -113,7 +143,10 @@ def test_lazyframe_none_present(base_df: pl.DataFrame):
 def test_insert_only_excludes_update_only(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
-        df, insert=True, delete=False, update=False,
+        df,
+        insert=True,
+        delete=False,
+        update=False,
     )
     assert col not in result
 
@@ -122,10 +155,15 @@ def test_insert_only_excludes_update_only(base_df: pl.DataFrame, col: str):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_includes_structure_sensitive(base_df: pl.DataFrame, col: str):
+def test_insert_only_includes_structure_sensitive(
+    base_df: pl.DataFrame, col: str
+):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
-        df, insert=True, delete=False, update=False,
+        df,
+        insert=True,
+        delete=False,
+        update=False,
     )
     assert result == [col]
 
@@ -134,7 +172,10 @@ def test_insert_only_includes_structure_sensitive(base_df: pl.DataFrame, col: st
 def test_delete_only_excludes_update_only(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
-        df, insert=False, delete=True, update=False,
+        df,
+        insert=False,
+        delete=True,
+        update=False,
     )
     assert col not in result
 
@@ -143,10 +184,15 @@ def test_delete_only_excludes_update_only(base_df: pl.DataFrame, col: str):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_delete_only_includes_structure_sensitive(base_df: pl.DataFrame, col: str):
+def test_delete_only_includes_structure_sensitive(
+    base_df: pl.DataFrame, col: str
+):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
-        df, insert=False, delete=True, update=False,
+        df,
+        insert=False,
+        delete=True,
+        update=False,
     )
     assert result == [col]
 
@@ -155,7 +201,10 @@ def test_delete_only_includes_structure_sensitive(base_df: pl.DataFrame, col: st
 def test_update_includes_all(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
-        df, insert=False, delete=False, update=True,
+        df,
+        insert=False,
+        delete=False,
+        update=True,
     )
     assert result == [col]
 
@@ -164,7 +213,10 @@ def test_no_ops_returns_empty(base_df: pl.DataFrame):
     cols = [pl.lit(0).alias(col) for col in _topologically_sensitive_cols]
     df = base_df.with_columns(cols)
     result = alifestd_check_topological_sensitivity_polars(
-        df, insert=False, delete=False, update=False,
+        df,
+        insert=False,
+        delete=False,
+        update=False,
     )
     assert result == []
 
@@ -173,7 +225,10 @@ def test_no_ops_returns_empty(base_df: pl.DataFrame):
 def test_insert_only_lazyframe_excludes(base_df: pl.DataFrame, col: str):
     lazy = base_df.with_columns(pl.lit(0).alias(col)).lazy()
     result = alifestd_check_topological_sensitivity_polars(
-        lazy, insert=True, delete=False, update=False,
+        lazy,
+        insert=True,
+        delete=False,
+        update=False,
     )
     assert col not in result
 
@@ -183,8 +238,11 @@ def test_warn_topological_sensitivity_polars_warns(base_df: pl.DataFrame):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity_polars(
-            df, "test_caller",
-            insert=False, delete=True, update=True,
+            df,
+            "test_caller",
+            insert=False,
+            delete=True,
+            update=True,
         )
         assert len(w) == 1
         assert "test_caller" in str(w[0].message)
@@ -199,8 +257,11 @@ def test_warn_topological_sensitivity_polars_silent(base_df: pl.DataFrame):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity_polars(
-            base_df, "test_caller",
-            insert=True, delete=True, update=True,
+            base_df,
+            "test_caller",
+            insert=True,
+            delete=True,
+            update=True,
         )
         assert len(w) == 0
 
@@ -212,20 +273,28 @@ def test_warn_topological_sensitivity_polars_lazyframe(base_df: pl.DataFrame):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity_polars(
-            lazy, "test_caller",
-            insert=False, delete=True, update=True,
+            lazy,
+            "test_caller",
+            insert=False,
+            delete=True,
+            update=True,
         )
         assert len(w) == 1
         assert "edge_length" in str(w[0].message)
 
 
-def test_warn_topological_sensitivity_polars_ops_in_message(base_df: pl.DataFrame):
+def test_warn_topological_sensitivity_polars_ops_in_message(
+    base_df: pl.DataFrame,
+):
     df = base_df.with_columns(pl.lit(0).alias("sister_id"))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity_polars(
-            df, "test_caller",
-            insert=True, delete=False, update=False,
+            df,
+            "test_caller",
+            insert=True,
+            delete=False,
+            update=False,
         )
         assert len(w) == 1
         assert "insert" in str(w[0].message)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity_polars.py
@@ -24,7 +24,7 @@ def base_df():
     )
 
 
-def test_none_present(base_df):
+def test_none_present(base_df: pl.DataFrame):
     result = alifestd_check_topological_sensitivity_polars(
         base_df, insert=True, delete=True, update=True,
     )
@@ -32,7 +32,7 @@ def test_none_present(base_df):
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_single_sensitive_col(base_df, col):
+def test_single_sensitive_col(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
         df, insert=True, delete=True, update=True,
@@ -40,7 +40,7 @@ def test_single_sensitive_col(base_df, col):
     assert result == [col]
 
 
-def test_multiple_sensitive_cols(base_df):
+def test_multiple_sensitive_cols(base_df: pl.DataFrame):
     df = base_df.with_columns(
         pl.lit(0).alias("branch_length"),
         pl.lit(0).alias("node_depth"),
@@ -52,7 +52,7 @@ def test_multiple_sensitive_cols(base_df):
     assert set(result) == {"branch_length", "node_depth", "sister_id"}
 
 
-def test_non_sensitive_cols_ignored(base_df):
+def test_non_sensitive_cols_ignored(base_df: pl.DataFrame):
     df = base_df.with_columns(
         pl.lit("x").alias("taxon_label"),
         pl.lit(True).alias("extant"),
@@ -63,7 +63,7 @@ def test_non_sensitive_cols_ignored(base_df):
     assert result == []
 
 
-def test_no_mutation(base_df):
+def test_no_mutation(base_df: pl.DataFrame):
     df = base_df.with_columns(pl.lit(0).alias("branch_length"))
     original = df.clone()
     alifestd_check_topological_sensitivity_polars(
@@ -92,7 +92,7 @@ def test_empty_dataframe_with_sensitive():
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_lazyframe(base_df, col):
+def test_lazyframe(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     lazy = df.lazy()
     result = alifestd_check_topological_sensitivity_polars(
@@ -101,7 +101,7 @@ def test_lazyframe(base_df, col):
     assert result == [col]
 
 
-def test_lazyframe_none_present(base_df):
+def test_lazyframe_none_present(base_df: pl.DataFrame):
     lazy = base_df.lazy()
     result = alifestd_check_topological_sensitivity_polars(
         lazy, insert=True, delete=True, update=True,
@@ -110,7 +110,7 @@ def test_lazyframe_none_present(base_df):
 
 
 @pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
-def test_insert_only_excludes_update_only(base_df, col):
+def test_insert_only_excludes_update_only(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
         df, insert=True, delete=False, update=False,
@@ -122,7 +122,7 @@ def test_insert_only_excludes_update_only(base_df, col):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_includes_structure_sensitive(base_df, col):
+def test_insert_only_includes_structure_sensitive(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
         df, insert=True, delete=False, update=False,
@@ -131,7 +131,7 @@ def test_insert_only_includes_structure_sensitive(base_df, col):
 
 
 @pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
-def test_delete_only_excludes_update_only(base_df, col):
+def test_delete_only_excludes_update_only(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
         df, insert=False, delete=True, update=False,
@@ -143,7 +143,7 @@ def test_delete_only_excludes_update_only(base_df, col):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_delete_only_includes_structure_sensitive(base_df, col):
+def test_delete_only_includes_structure_sensitive(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
         df, insert=False, delete=True, update=False,
@@ -152,7 +152,7 @@ def test_delete_only_includes_structure_sensitive(base_df, col):
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_update_includes_all(base_df, col):
+def test_update_includes_all(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_check_topological_sensitivity_polars(
         df, insert=False, delete=False, update=True,
@@ -160,7 +160,7 @@ def test_update_includes_all(base_df, col):
     assert result == [col]
 
 
-def test_no_ops_returns_empty(base_df):
+def test_no_ops_returns_empty(base_df: pl.DataFrame):
     cols = [pl.lit(0).alias(col) for col in _topologically_sensitive_cols]
     df = base_df.with_columns(cols)
     result = alifestd_check_topological_sensitivity_polars(
@@ -170,7 +170,7 @@ def test_no_ops_returns_empty(base_df):
 
 
 @pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
-def test_insert_only_lazyframe_excludes(base_df, col):
+def test_insert_only_lazyframe_excludes(base_df: pl.DataFrame, col: str):
     lazy = base_df.with_columns(pl.lit(0).alias(col)).lazy()
     result = alifestd_check_topological_sensitivity_polars(
         lazy, insert=True, delete=False, update=False,
@@ -178,7 +178,7 @@ def test_insert_only_lazyframe_excludes(base_df, col):
     assert col not in result
 
 
-def test_warn_topological_sensitivity_polars_warns(base_df):
+def test_warn_topological_sensitivity_polars_warns(base_df: pl.DataFrame):
     df = base_df.with_columns(pl.lit(0).alias("branch_length"))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
@@ -190,12 +190,12 @@ def test_warn_topological_sensitivity_polars_warns(base_df):
         assert "test_caller" in str(w[0].message)
         assert "branch_length" in str(w[0].message)
         assert "delete/update" in str(w[0].message)
-        assert "alifestd_drop_topological_sensitivity_polars" in str(
+        assert "alifestd_drop_topological_sensitivity" in str(
             w[0].message,
         )
 
 
-def test_warn_topological_sensitivity_polars_silent(base_df):
+def test_warn_topological_sensitivity_polars_silent(base_df: pl.DataFrame):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         alifestd_warn_topological_sensitivity_polars(
@@ -205,7 +205,7 @@ def test_warn_topological_sensitivity_polars_silent(base_df):
         assert len(w) == 0
 
 
-def test_warn_topological_sensitivity_polars_lazyframe(base_df):
+def test_warn_topological_sensitivity_polars_lazyframe(base_df: pl.DataFrame):
     lazy = base_df.with_columns(
         pl.lit(0).alias("edge_length"),
     ).lazy()
@@ -219,7 +219,7 @@ def test_warn_topological_sensitivity_polars_lazyframe(base_df):
         assert "edge_length" in str(w[0].message)
 
 
-def test_warn_topological_sensitivity_polars_ops_in_message(base_df):
+def test_warn_topological_sensitivity_polars_ops_in_message(base_df: pl.DataFrame):
     df = base_df.with_columns(pl.lit(0).alias("sister_id"))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_check_topological_sensitivity_polars.py
@@ -1,0 +1,129 @@
+import warnings
+
+import polars as pl
+import pytest
+
+from hstrat._auxiliary_lib import (
+    alifestd_check_topological_sensitivity_polars,
+    alifestd_warn_topological_sensitivity_polars,
+)
+from hstrat._auxiliary_lib._alifestd_check_topological_sensitivity import (
+    _topologically_sensitive_cols,
+)
+
+
+@pytest.fixture
+def base_df():
+    return pl.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_id": [0, 0, 1],
+            "origin_time": [0, 1, 2],
+        }
+    )
+
+
+def test_none_present(base_df):
+    result = alifestd_check_topological_sensitivity_polars(base_df)
+    assert result == []
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_single_sensitive_col(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_check_topological_sensitivity_polars(df)
+    assert result == [col]
+
+
+def test_multiple_sensitive_cols(base_df):
+    df = base_df.with_columns(
+        pl.lit(0).alias("branch_length"),
+        pl.lit(0).alias("node_depth"),
+        pl.lit(0).alias("sister_id"),
+    )
+    result = alifestd_check_topological_sensitivity_polars(df)
+    assert set(result) == {"branch_length", "node_depth", "sister_id"}
+
+
+def test_non_sensitive_cols_ignored(base_df):
+    df = base_df.with_columns(
+        pl.lit("x").alias("taxon_label"),
+        pl.lit(True).alias("extant"),
+    )
+    result = alifestd_check_topological_sensitivity_polars(df)
+    assert result == []
+
+
+def test_no_mutation(base_df):
+    df = base_df.with_columns(pl.lit(0).alias("branch_length"))
+    original = df.clone()
+    alifestd_check_topological_sensitivity_polars(df)
+    assert df.equals(original)
+
+
+def test_empty_dataframe():
+    df = pl.DataFrame({"id": pl.Series([], dtype=pl.Int64)})
+    assert alifestd_check_topological_sensitivity_polars(df) == []
+
+
+def test_empty_dataframe_with_sensitive():
+    df = pl.DataFrame(
+        {
+            "id": pl.Series([], dtype=pl.Int64),
+            "branch_length": pl.Series([], dtype=pl.Float64),
+        }
+    )
+    assert alifestd_check_topological_sensitivity_polars(df) == [
+        "branch_length"
+    ]
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_lazyframe(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    lazy = df.lazy()
+    result = alifestd_check_topological_sensitivity_polars(lazy)
+    assert result == [col]
+
+
+def test_lazyframe_none_present(base_df):
+    lazy = base_df.lazy()
+    result = alifestd_check_topological_sensitivity_polars(lazy)
+    assert result == []
+
+
+def test_warn_topological_sensitivity_polars_warns(base_df):
+    df = base_df.with_columns(pl.lit(0).alias("branch_length"))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_warn_topological_sensitivity_polars(
+            df, "test_caller",
+        )
+        assert len(w) == 1
+        assert "test_caller" in str(w[0].message)
+        assert "branch_length" in str(w[0].message)
+        assert "alifestd_drop_topological_sensitivity_polars" in str(
+            w[0].message,
+        )
+
+
+def test_warn_topological_sensitivity_polars_silent(base_df):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_warn_topological_sensitivity_polars(
+            base_df, "test_caller",
+        )
+        assert len(w) == 0
+
+
+def test_warn_topological_sensitivity_polars_lazyframe(base_df):
+    lazy = base_df.with_columns(
+        pl.lit(0).alias("edge_length"),
+    ).lazy()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_warn_topological_sensitivity_polars(
+            lazy, "test_caller",
+        )
+        assert len(w) == 1
+        assert "edge_length" in str(w[0].message)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity.py
@@ -1,15 +1,14 @@
 import pandas as pd
-import polars as pl
 import pytest
 
-from hstrat._auxiliary_lib import (
-    alifestd_drop_topological_sensitivity,
-    alifestd_drop_topological_sensitivity_polars,
+from hstrat._auxiliary_lib import alifestd_drop_topological_sensitivity
+from hstrat._auxiliary_lib._alifestd_check_topological_sensitivity import (
+    _topologically_sensitive_cols,
 )
 
 
 @pytest.fixture
-def base_df_pandas():
+def base_df():
     return pd.DataFrame(
         {
             "id": [0, 1, 2],
@@ -19,178 +18,68 @@ def base_df_pandas():
     )
 
 
-@pytest.fixture
-def base_df_polars():
-    return pl.DataFrame(
+def test_drop_none(base_df):
+    original = base_df.copy()
+    result = alifestd_drop_topological_sensitivity(base_df)
+    assert set(result.columns) == set(original.columns)
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_drop_single(base_df, col):
+    df = base_df.copy()
+    df[col] = 0
+    result = alifestd_drop_topological_sensitivity(df)
+    assert col not in result.columns
+    assert "id" in result.columns
+
+
+def test_drop_multiple(base_df):
+    df = base_df.copy()
+    df["branch_length"] = 0.0
+    df["node_depth"] = 0
+    df["sister_id"] = 0
+    df["taxon_label"] = "x"
+    result = alifestd_drop_topological_sensitivity(df)
+    assert "branch_length" not in result.columns
+    assert "node_depth" not in result.columns
+    assert "sister_id" not in result.columns
+    assert "taxon_label" in result.columns
+    assert "id" in result.columns
+
+
+def test_preserves_non_sensitive(base_df):
+    df = base_df.copy()
+    df["taxon_label"] = "x"
+    df["extant"] = True
+    df["branch_length"] = 0.0
+    result = alifestd_drop_topological_sensitivity(df)
+    expected_cols = {
+        "id", "ancestor_id", "origin_time", "taxon_label", "extant",
+    }
+    assert set(result.columns) == expected_cols
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_mutate(base_df, mutate):
+    df = base_df.copy()
+    df["branch_length"] = 0.0
+    original = df.copy()
+    result = alifestd_drop_topological_sensitivity(df, mutate=mutate)
+    assert "branch_length" not in result.columns
+    if mutate:
+        assert "branch_length" not in df.columns
+    else:
+        pd.testing.assert_frame_equal(df, original)
+
+
+def test_empty():
+    df = pd.DataFrame(
         {
-            "id": [0, 1, 2],
-            "ancestor_id": [0, 0, 1],
-            "origin_time": [0, 1, 2],
+            "id": pd.Series([], dtype=int),
+            "branch_length": pd.Series([], dtype=float),
         }
     )
-
-
-class TestDropNone:
-    def test_pandas(self, base_df_pandas):
-        result = alifestd_drop_topological_sensitivity(base_df_pandas)
-        pd.testing.assert_frame_equal(result, base_df_pandas)
-
-    def test_polars(self, base_df_polars):
-        result = alifestd_drop_topological_sensitivity_polars(base_df_polars)
-        assert result.equals(base_df_polars)
-
-
-class TestDropSingle:
-    def test_pandas(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        df["branch_length"] = [0.0, 1.0, 1.0]
-        result = alifestd_drop_topological_sensitivity(df)
-        assert "branch_length" not in result.columns
-        assert "id" in result.columns
-        assert "ancestor_id" in result.columns
-        assert "origin_time" in result.columns
-
-    def test_polars(self, base_df_polars):
-        df = base_df_polars.with_columns(
-            pl.lit(0.0).alias("branch_length"),
-        )
-        result = alifestd_drop_topological_sensitivity_polars(df)
-        assert "branch_length" not in result.columns
-        assert "id" in result.columns
-        assert "ancestor_id" in result.columns
-        assert "origin_time" in result.columns
-
-
-class TestDropMultiple:
-    def test_pandas(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        df["branch_length"] = 0.0
-        df["node_depth"] = 0
-        df["sister_id"] = 0
-        df["taxon_label"] = "x"
-        result = alifestd_drop_topological_sensitivity(df)
-        assert "branch_length" not in result.columns
-        assert "node_depth" not in result.columns
-        assert "sister_id" not in result.columns
-        assert "taxon_label" in result.columns
-        assert "id" in result.columns
-
-    def test_polars(self, base_df_polars):
-        df = base_df_polars.with_columns(
-            pl.lit(0.0).alias("branch_length"),
-            pl.lit(0).alias("node_depth"),
-            pl.lit(0).alias("sister_id"),
-            pl.lit("x").alias("taxon_label"),
-        )
-        result = alifestd_drop_topological_sensitivity_polars(df)
-        assert "branch_length" not in result.columns
-        assert "node_depth" not in result.columns
-        assert "sister_id" not in result.columns
-        assert "taxon_label" in result.columns
-        assert "id" in result.columns
-
-
-class TestPreservesNonSensitive:
-    def test_pandas(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        df["taxon_label"] = "x"
-        df["extant"] = True
-        df["branch_length"] = 0.0
-        result = alifestd_drop_topological_sensitivity(df)
-        expected_cols = {"id", "ancestor_id", "origin_time", "taxon_label", "extant"}
-        assert set(result.columns) == expected_cols
-
-    def test_polars(self, base_df_polars):
-        df = base_df_polars.with_columns(
-            pl.lit("x").alias("taxon_label"),
-            pl.lit(True).alias("extant"),
-            pl.lit(0.0).alias("branch_length"),
-        )
-        result = alifestd_drop_topological_sensitivity_polars(df)
-        expected_cols = {"id", "ancestor_id", "origin_time", "taxon_label", "extant"}
-        assert set(result.columns) == expected_cols
-
-
-class TestMutate:
-    def test_pandas_mutate_false(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        df["branch_length"] = 0.0
-        original = df.copy()
-        result = alifestd_drop_topological_sensitivity(df, mutate=False)
-        pd.testing.assert_frame_equal(df, original)
-        assert "branch_length" not in result.columns
-
-    def test_pandas_mutate_true(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        df["branch_length"] = 0.0
-        result = alifestd_drop_topological_sensitivity(df, mutate=True)
-        assert "branch_length" not in result.columns
-        assert "branch_length" not in df.columns
-
-
-class TestEmpty:
-    def test_pandas(self):
-        df = pd.DataFrame(
-            {
-                "id": pd.Series([], dtype=int),
-                "branch_length": pd.Series([], dtype=float),
-            }
-        )
-        result = alifestd_drop_topological_sensitivity(df)
-        assert "branch_length" not in result.columns
-        assert "id" in result.columns
-        assert len(result) == 0
-
-    def test_polars(self):
-        df = pl.DataFrame(
-            {
-                "id": pl.Series([], dtype=pl.Int64),
-                "branch_length": pl.Series([], dtype=pl.Float64),
-            }
-        )
-        result = alifestd_drop_topological_sensitivity_polars(df)
-        assert "branch_length" not in result.columns
-        assert "id" in result.columns
-        assert len(result) == 0
-
-
-class TestAllSensitiveColumns:
-    """Test dropping all known sensitive columns at once."""
-
-    def test_pandas(self, base_df_pandas):
-        df = base_df_pandas.copy()
-        sensitive = [
-            "ancestor_origin_time",
-            "branch_length",
-            "clade_duration",
-            "edge_length",
-            "node_depth",
-            "num_children",
-            "num_descendants",
-            "num_leaves",
-            "origin_time_delta",
-            "sister_id",
-        ]
-        for col in sensitive:
-            df[col] = 0
-        result = alifestd_drop_topological_sensitivity(df)
-        for col in sensitive:
-            assert col not in result.columns
-        assert set(result.columns) == {"id", "ancestor_id", "origin_time"}
-
-    def test_polars(self, base_df_polars):
-        sensitive = [
-            "ancestor_origin_time",
-            "branch_length",
-            "clade_duration",
-            "edge_length",
-            "node_depth",
-            "num_children",
-        ]
-        df = base_df_polars.with_columns(
-            *(pl.lit(0).alias(col) for col in sensitive)
-        )
-        result = alifestd_drop_topological_sensitivity_polars(df)
-        for col in sensitive:
-            assert col not in result.columns
-        assert set(result.columns) == {"id", "ancestor_id", "origin_time"}
+    result = alifestd_drop_topological_sensitivity(df)
+    assert "branch_length" not in result.columns
+    assert "id" in result.columns
+    assert len(result) == 0

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity.py
@@ -3,8 +3,8 @@ import pytest
 
 from hstrat._auxiliary_lib import alifestd_drop_topological_sensitivity
 from hstrat._auxiliary_lib._alifestd_check_topological_sensitivity import (
-    _insert_insensitive_cols,
     _topologically_sensitive_cols,
+    _update_only_sensitive_cols,
 )
 
 
@@ -86,8 +86,8 @@ def test_empty():
     assert len(result) == 0
 
 
-@pytest.mark.parametrize("col", sorted(_insert_insensitive_cols))
-def test_insert_only_preserves_insert_insensitive(base_df, col):
+@pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
+def test_insert_only_preserves_update_only(base_df, col):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
@@ -98,9 +98,9 @@ def test_insert_only_preserves_insert_insensitive(base_df, col):
 
 @pytest.mark.parametrize(
     "col",
-    sorted(_topologically_sensitive_cols - _insert_insensitive_cols),
+    sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_drops_insert_sensitive(base_df, col):
+def test_insert_only_drops_structure_sensitive(base_df, col):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
@@ -109,8 +109,21 @@ def test_insert_only_drops_insert_sensitive(base_df, col):
     assert col not in result.columns
 
 
-@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_delete_drops_all(base_df, col):
+@pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
+def test_delete_only_preserves_update_only(base_df, col):
+    df = base_df.copy()
+    df[col] = 0
+    result = alifestd_drop_topological_sensitivity(
+        df, insert=False, delete=True, update=False,
+    )
+    assert col in result.columns
+
+
+@pytest.mark.parametrize(
+    "col",
+    sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
+)
+def test_delete_only_drops_structure_sensitive(base_df, col):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity.py
@@ -1,0 +1,196 @@
+import pandas as pd
+import polars as pl
+import pytest
+
+from hstrat._auxiliary_lib import (
+    alifestd_drop_topological_sensitivity,
+    alifestd_drop_topological_sensitivity_polars,
+)
+
+
+@pytest.fixture
+def base_df_pandas():
+    return pd.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_id": [0, 0, 1],
+            "origin_time": [0, 1, 2],
+        }
+    )
+
+
+@pytest.fixture
+def base_df_polars():
+    return pl.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_id": [0, 0, 1],
+            "origin_time": [0, 1, 2],
+        }
+    )
+
+
+class TestDropNone:
+    def test_pandas(self, base_df_pandas):
+        result = alifestd_drop_topological_sensitivity(base_df_pandas)
+        pd.testing.assert_frame_equal(result, base_df_pandas)
+
+    def test_polars(self, base_df_polars):
+        result = alifestd_drop_topological_sensitivity_polars(base_df_polars)
+        assert result.equals(base_df_polars)
+
+
+class TestDropSingle:
+    def test_pandas(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        df["branch_length"] = [0.0, 1.0, 1.0]
+        result = alifestd_drop_topological_sensitivity(df)
+        assert "branch_length" not in result.columns
+        assert "id" in result.columns
+        assert "ancestor_id" in result.columns
+        assert "origin_time" in result.columns
+
+    def test_polars(self, base_df_polars):
+        df = base_df_polars.with_columns(
+            pl.lit(0.0).alias("branch_length"),
+        )
+        result = alifestd_drop_topological_sensitivity_polars(df)
+        assert "branch_length" not in result.columns
+        assert "id" in result.columns
+        assert "ancestor_id" in result.columns
+        assert "origin_time" in result.columns
+
+
+class TestDropMultiple:
+    def test_pandas(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        df["branch_length"] = 0.0
+        df["node_depth"] = 0
+        df["sister_id"] = 0
+        df["taxon_label"] = "x"
+        result = alifestd_drop_topological_sensitivity(df)
+        assert "branch_length" not in result.columns
+        assert "node_depth" not in result.columns
+        assert "sister_id" not in result.columns
+        assert "taxon_label" in result.columns
+        assert "id" in result.columns
+
+    def test_polars(self, base_df_polars):
+        df = base_df_polars.with_columns(
+            pl.lit(0.0).alias("branch_length"),
+            pl.lit(0).alias("node_depth"),
+            pl.lit(0).alias("sister_id"),
+            pl.lit("x").alias("taxon_label"),
+        )
+        result = alifestd_drop_topological_sensitivity_polars(df)
+        assert "branch_length" not in result.columns
+        assert "node_depth" not in result.columns
+        assert "sister_id" not in result.columns
+        assert "taxon_label" in result.columns
+        assert "id" in result.columns
+
+
+class TestPreservesNonSensitive:
+    def test_pandas(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        df["taxon_label"] = "x"
+        df["extant"] = True
+        df["branch_length"] = 0.0
+        result = alifestd_drop_topological_sensitivity(df)
+        expected_cols = {"id", "ancestor_id", "origin_time", "taxon_label", "extant"}
+        assert set(result.columns) == expected_cols
+
+    def test_polars(self, base_df_polars):
+        df = base_df_polars.with_columns(
+            pl.lit("x").alias("taxon_label"),
+            pl.lit(True).alias("extant"),
+            pl.lit(0.0).alias("branch_length"),
+        )
+        result = alifestd_drop_topological_sensitivity_polars(df)
+        expected_cols = {"id", "ancestor_id", "origin_time", "taxon_label", "extant"}
+        assert set(result.columns) == expected_cols
+
+
+class TestMutate:
+    def test_pandas_mutate_false(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        df["branch_length"] = 0.0
+        original = df.copy()
+        result = alifestd_drop_topological_sensitivity(df, mutate=False)
+        pd.testing.assert_frame_equal(df, original)
+        assert "branch_length" not in result.columns
+
+    def test_pandas_mutate_true(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        df["branch_length"] = 0.0
+        result = alifestd_drop_topological_sensitivity(df, mutate=True)
+        assert "branch_length" not in result.columns
+        assert "branch_length" not in df.columns
+
+
+class TestEmpty:
+    def test_pandas(self):
+        df = pd.DataFrame(
+            {
+                "id": pd.Series([], dtype=int),
+                "branch_length": pd.Series([], dtype=float),
+            }
+        )
+        result = alifestd_drop_topological_sensitivity(df)
+        assert "branch_length" not in result.columns
+        assert "id" in result.columns
+        assert len(result) == 0
+
+    def test_polars(self):
+        df = pl.DataFrame(
+            {
+                "id": pl.Series([], dtype=pl.Int64),
+                "branch_length": pl.Series([], dtype=pl.Float64),
+            }
+        )
+        result = alifestd_drop_topological_sensitivity_polars(df)
+        assert "branch_length" not in result.columns
+        assert "id" in result.columns
+        assert len(result) == 0
+
+
+class TestAllSensitiveColumns:
+    """Test dropping all known sensitive columns at once."""
+
+    def test_pandas(self, base_df_pandas):
+        df = base_df_pandas.copy()
+        sensitive = [
+            "ancestor_origin_time",
+            "branch_length",
+            "clade_duration",
+            "edge_length",
+            "node_depth",
+            "num_children",
+            "num_descendants",
+            "num_leaves",
+            "origin_time_delta",
+            "sister_id",
+        ]
+        for col in sensitive:
+            df[col] = 0
+        result = alifestd_drop_topological_sensitivity(df)
+        for col in sensitive:
+            assert col not in result.columns
+        assert set(result.columns) == {"id", "ancestor_id", "origin_time"}
+
+    def test_polars(self, base_df_polars):
+        sensitive = [
+            "ancestor_origin_time",
+            "branch_length",
+            "clade_duration",
+            "edge_length",
+            "node_depth",
+            "num_children",
+        ]
+        df = base_df_polars.with_columns(
+            *(pl.lit(0).alias(col) for col in sensitive)
+        )
+        result = alifestd_drop_topological_sensitivity_polars(df)
+        for col in sensitive:
+            assert col not in result.columns
+        assert set(result.columns) == {"id", "ancestor_id", "origin_time"}

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity.py
@@ -55,7 +55,11 @@ def test_preserves_non_sensitive(base_df: pd.DataFrame):
     df["branch_length"] = 0.0
     result = alifestd_drop_topological_sensitivity(df)
     expected_cols = {
-        "id", "ancestor_id", "origin_time", "taxon_label", "extant",
+        "id",
+        "ancestor_id",
+        "origin_time",
+        "taxon_label",
+        "extant",
     }
     assert set(result.columns) == expected_cols
 
@@ -91,7 +95,10 @@ def test_insert_only_preserves_update_only(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
-        df, insert=True, delete=False, update=False,
+        df,
+        insert=True,
+        delete=False,
+        update=False,
     )
     assert col in result.columns
 
@@ -100,11 +107,16 @@ def test_insert_only_preserves_update_only(base_df: pd.DataFrame, col: str):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_drops_structure_sensitive(base_df: pd.DataFrame, col: str):
+def test_insert_only_drops_structure_sensitive(
+    base_df: pd.DataFrame, col: str
+):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
-        df, insert=True, delete=False, update=False,
+        df,
+        insert=True,
+        delete=False,
+        update=False,
     )
     assert col not in result.columns
 
@@ -114,7 +126,10 @@ def test_delete_only_preserves_update_only(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
-        df, insert=False, delete=True, update=False,
+        df,
+        insert=False,
+        delete=True,
+        update=False,
     )
     assert col in result.columns
 
@@ -123,11 +138,16 @@ def test_delete_only_preserves_update_only(base_df: pd.DataFrame, col: str):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_delete_only_drops_structure_sensitive(base_df: pd.DataFrame, col: str):
+def test_delete_only_drops_structure_sensitive(
+    base_df: pd.DataFrame, col: str
+):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
-        df, insert=False, delete=True, update=False,
+        df,
+        insert=False,
+        delete=True,
+        update=False,
     )
     assert col not in result.columns
 
@@ -137,7 +157,10 @@ def test_update_drops_all(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
-        df, insert=False, delete=False, update=True,
+        df,
+        insert=False,
+        delete=False,
+        update=True,
     )
     assert col not in result.columns
 
@@ -147,7 +170,10 @@ def test_no_ops_drops_nothing(base_df: pd.DataFrame):
     df["branch_length"] = 0.0
     df["sister_id"] = 0
     result = alifestd_drop_topological_sensitivity(
-        df, insert=False, delete=False, update=False,
+        df,
+        insert=False,
+        delete=False,
+        update=False,
     )
     assert "branch_length" in result.columns
     assert "sister_id" in result.columns

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity.py
@@ -19,14 +19,14 @@ def base_df():
     )
 
 
-def test_drop_none(base_df):
+def test_drop_none(base_df: pd.DataFrame):
     original = base_df.copy()
     result = alifestd_drop_topological_sensitivity(base_df)
     assert set(result.columns) == set(original.columns)
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_drop_single(base_df, col):
+def test_drop_single(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(df)
@@ -34,7 +34,7 @@ def test_drop_single(base_df, col):
     assert "id" in result.columns
 
 
-def test_drop_multiple(base_df):
+def test_drop_multiple(base_df: pd.DataFrame):
     df = base_df.copy()
     df["branch_length"] = 0.0
     df["node_depth"] = 0
@@ -48,7 +48,7 @@ def test_drop_multiple(base_df):
     assert "id" in result.columns
 
 
-def test_preserves_non_sensitive(base_df):
+def test_preserves_non_sensitive(base_df: pd.DataFrame):
     df = base_df.copy()
     df["taxon_label"] = "x"
     df["extant"] = True
@@ -61,7 +61,7 @@ def test_preserves_non_sensitive(base_df):
 
 
 @pytest.mark.parametrize("mutate", [False, True])
-def test_mutate(base_df, mutate):
+def test_mutate(base_df: pd.DataFrame, mutate: bool):
     df = base_df.copy()
     df["branch_length"] = 0.0
     original = df.copy()
@@ -87,7 +87,7 @@ def test_empty():
 
 
 @pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
-def test_insert_only_preserves_update_only(base_df, col):
+def test_insert_only_preserves_update_only(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
@@ -100,7 +100,7 @@ def test_insert_only_preserves_update_only(base_df, col):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_drops_structure_sensitive(base_df, col):
+def test_insert_only_drops_structure_sensitive(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
@@ -110,7 +110,7 @@ def test_insert_only_drops_structure_sensitive(base_df, col):
 
 
 @pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
-def test_delete_only_preserves_update_only(base_df, col):
+def test_delete_only_preserves_update_only(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
@@ -123,7 +123,7 @@ def test_delete_only_preserves_update_only(base_df, col):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_delete_only_drops_structure_sensitive(base_df, col):
+def test_delete_only_drops_structure_sensitive(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
@@ -133,7 +133,7 @@ def test_delete_only_drops_structure_sensitive(base_df, col):
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_update_drops_all(base_df, col):
+def test_update_drops_all(base_df: pd.DataFrame, col: str):
     df = base_df.copy()
     df[col] = 0
     result = alifestd_drop_topological_sensitivity(
@@ -142,7 +142,7 @@ def test_update_drops_all(base_df, col):
     assert col not in result.columns
 
 
-def test_no_ops_drops_nothing(base_df):
+def test_no_ops_drops_nothing(base_df: pd.DataFrame):
     df = base_df.copy()
     df["branch_length"] = 0.0
     df["sister_id"] = 0

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity_polars.py
@@ -5,8 +5,8 @@ from hstrat._auxiliary_lib import (
     alifestd_drop_topological_sensitivity_polars,
 )
 from hstrat._auxiliary_lib._alifestd_check_topological_sensitivity import (
-    _insert_insensitive_cols,
     _topologically_sensitive_cols,
+    _update_only_sensitive_cols,
 )
 
 
@@ -75,8 +75,8 @@ def test_empty():
     assert len(result) == 0
 
 
-@pytest.mark.parametrize("col", sorted(_insert_insensitive_cols))
-def test_insert_only_preserves_insert_insensitive(base_df, col):
+@pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
+def test_insert_only_preserves_update_only(base_df, col):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
         df, insert=True, delete=False, update=False,
@@ -86,9 +86,9 @@ def test_insert_only_preserves_insert_insensitive(base_df, col):
 
 @pytest.mark.parametrize(
     "col",
-    sorted(_topologically_sensitive_cols - _insert_insensitive_cols),
+    sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_drops_insert_sensitive(base_df, col):
+def test_insert_only_drops_structure_sensitive(base_df, col):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
         df, insert=True, delete=False, update=False,
@@ -96,8 +96,20 @@ def test_insert_only_drops_insert_sensitive(base_df, col):
     assert col not in result.columns
 
 
-@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_delete_drops_all(base_df, col):
+@pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
+def test_delete_only_preserves_update_only(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_drop_topological_sensitivity_polars(
+        df, insert=False, delete=True, update=False,
+    )
+    assert col in result.columns
+
+
+@pytest.mark.parametrize(
+    "col",
+    sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
+)
+def test_delete_only_drops_structure_sensitive(base_df, col):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
         df, insert=False, delete=True, update=False,

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity_polars.py
@@ -1,0 +1,74 @@
+import polars as pl
+import pytest
+
+from hstrat._auxiliary_lib import (
+    alifestd_drop_topological_sensitivity_polars,
+)
+from hstrat._auxiliary_lib._alifestd_check_topological_sensitivity import (
+    _topologically_sensitive_cols,
+)
+
+
+@pytest.fixture
+def base_df():
+    return pl.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_id": [0, 0, 1],
+            "origin_time": [0, 1, 2],
+        }
+    )
+
+
+def test_drop_none(base_df):
+    result = alifestd_drop_topological_sensitivity_polars(base_df)
+    assert set(result.columns) == set(base_df.columns)
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_drop_single(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_drop_topological_sensitivity_polars(df)
+    assert col not in result.columns
+    assert "id" in result.columns
+
+
+def test_drop_multiple(base_df):
+    df = base_df.with_columns(
+        pl.lit(0.0).alias("branch_length"),
+        pl.lit(0).alias("node_depth"),
+        pl.lit(0).alias("sister_id"),
+        pl.lit("x").alias("taxon_label"),
+    )
+    result = alifestd_drop_topological_sensitivity_polars(df)
+    assert "branch_length" not in result.columns
+    assert "node_depth" not in result.columns
+    assert "sister_id" not in result.columns
+    assert "taxon_label" in result.columns
+    assert "id" in result.columns
+
+
+def test_preserves_non_sensitive(base_df):
+    df = base_df.with_columns(
+        pl.lit("x").alias("taxon_label"),
+        pl.lit(True).alias("extant"),
+        pl.lit(0.0).alias("branch_length"),
+    )
+    result = alifestd_drop_topological_sensitivity_polars(df)
+    expected_cols = {
+        "id", "ancestor_id", "origin_time", "taxon_label", "extant",
+    }
+    assert set(result.columns) == expected_cols
+
+
+def test_empty():
+    df = pl.DataFrame(
+        {
+            "id": pl.Series([], dtype=pl.Int64),
+            "branch_length": pl.Series([], dtype=pl.Float64),
+        }
+    )
+    result = alifestd_drop_topological_sensitivity_polars(df)
+    assert "branch_length" not in result.columns
+    assert "id" in result.columns
+    assert len(result) == 0

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity_polars.py
@@ -57,7 +57,11 @@ def test_preserves_non_sensitive(base_df: pl.DataFrame):
     )
     result = alifestd_drop_topological_sensitivity_polars(df)
     expected_cols = {
-        "id", "ancestor_id", "origin_time", "taxon_label", "extant",
+        "id",
+        "ancestor_id",
+        "origin_time",
+        "taxon_label",
+        "extant",
     }
     assert set(result.columns) == expected_cols
 
@@ -79,7 +83,10 @@ def test_empty():
 def test_insert_only_preserves_update_only(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
-        df, insert=True, delete=False, update=False,
+        df,
+        insert=True,
+        delete=False,
+        update=False,
     )
     assert col in result.columns
 
@@ -88,10 +95,15 @@ def test_insert_only_preserves_update_only(base_df: pl.DataFrame, col: str):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_drops_structure_sensitive(base_df: pl.DataFrame, col: str):
+def test_insert_only_drops_structure_sensitive(
+    base_df: pl.DataFrame, col: str
+):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
-        df, insert=True, delete=False, update=False,
+        df,
+        insert=True,
+        delete=False,
+        update=False,
     )
     assert col not in result.columns
 
@@ -100,7 +112,10 @@ def test_insert_only_drops_structure_sensitive(base_df: pl.DataFrame, col: str):
 def test_delete_only_preserves_update_only(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
-        df, insert=False, delete=True, update=False,
+        df,
+        insert=False,
+        delete=True,
+        update=False,
     )
     assert col in result.columns
 
@@ -109,10 +124,15 @@ def test_delete_only_preserves_update_only(base_df: pl.DataFrame, col: str):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_delete_only_drops_structure_sensitive(base_df: pl.DataFrame, col: str):
+def test_delete_only_drops_structure_sensitive(
+    base_df: pl.DataFrame, col: str
+):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
-        df, insert=False, delete=True, update=False,
+        df,
+        insert=False,
+        delete=True,
+        update=False,
     )
     assert col not in result.columns
 
@@ -121,7 +141,10 @@ def test_delete_only_drops_structure_sensitive(base_df: pl.DataFrame, col: str):
 def test_update_drops_all(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
-        df, insert=False, delete=False, update=True,
+        df,
+        insert=False,
+        delete=False,
+        update=True,
     )
     assert col not in result.columns
 
@@ -132,7 +155,10 @@ def test_no_ops_drops_nothing(base_df: pl.DataFrame):
         pl.lit(0).alias("sister_id"),
     )
     result = alifestd_drop_topological_sensitivity_polars(
-        df, insert=False, delete=False, update=False,
+        df,
+        insert=False,
+        delete=False,
+        update=False,
     )
     assert "branch_length" in result.columns
     assert "sister_id" in result.columns

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity_polars.py
@@ -21,20 +21,20 @@ def base_df():
     )
 
 
-def test_drop_none(base_df):
+def test_drop_none(base_df: pl.DataFrame):
     result = alifestd_drop_topological_sensitivity_polars(base_df)
     assert set(result.columns) == set(base_df.columns)
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_drop_single(base_df, col):
+def test_drop_single(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(df)
     assert col not in result.columns
     assert "id" in result.columns
 
 
-def test_drop_multiple(base_df):
+def test_drop_multiple(base_df: pl.DataFrame):
     df = base_df.with_columns(
         pl.lit(0.0).alias("branch_length"),
         pl.lit(0).alias("node_depth"),
@@ -49,7 +49,7 @@ def test_drop_multiple(base_df):
     assert "id" in result.columns
 
 
-def test_preserves_non_sensitive(base_df):
+def test_preserves_non_sensitive(base_df: pl.DataFrame):
     df = base_df.with_columns(
         pl.lit("x").alias("taxon_label"),
         pl.lit(True).alias("extant"),
@@ -76,7 +76,7 @@ def test_empty():
 
 
 @pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
-def test_insert_only_preserves_update_only(base_df, col):
+def test_insert_only_preserves_update_only(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
         df, insert=True, delete=False, update=False,
@@ -88,7 +88,7 @@ def test_insert_only_preserves_update_only(base_df, col):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_insert_only_drops_structure_sensitive(base_df, col):
+def test_insert_only_drops_structure_sensitive(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
         df, insert=True, delete=False, update=False,
@@ -97,7 +97,7 @@ def test_insert_only_drops_structure_sensitive(base_df, col):
 
 
 @pytest.mark.parametrize("col", sorted(_update_only_sensitive_cols))
-def test_delete_only_preserves_update_only(base_df, col):
+def test_delete_only_preserves_update_only(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
         df, insert=False, delete=True, update=False,
@@ -109,7 +109,7 @@ def test_delete_only_preserves_update_only(base_df, col):
     "col",
     sorted(_topologically_sensitive_cols - _update_only_sensitive_cols),
 )
-def test_delete_only_drops_structure_sensitive(base_df, col):
+def test_delete_only_drops_structure_sensitive(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
         df, insert=False, delete=True, update=False,
@@ -118,7 +118,7 @@ def test_delete_only_drops_structure_sensitive(base_df, col):
 
 
 @pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
-def test_update_drops_all(base_df, col):
+def test_update_drops_all(base_df: pl.DataFrame, col: str):
     df = base_df.with_columns(pl.lit(0).alias(col))
     result = alifestd_drop_topological_sensitivity_polars(
         df, insert=False, delete=False, update=True,
@@ -126,7 +126,7 @@ def test_update_drops_all(base_df, col):
     assert col not in result.columns
 
 
-def test_no_ops_drops_nothing(base_df):
+def test_no_ops_drops_nothing(base_df: pl.DataFrame):
     df = base_df.with_columns(
         pl.lit(0.0).alias("branch_length"),
         pl.lit(0).alias("sister_id"),

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_drop_topological_sensitivity_polars.py
@@ -5,6 +5,7 @@ from hstrat._auxiliary_lib import (
     alifestd_drop_topological_sensitivity_polars,
 )
 from hstrat._auxiliary_lib._alifestd_check_topological_sensitivity import (
+    _insert_insensitive_cols,
     _topologically_sensitive_cols,
 )
 
@@ -72,3 +73,54 @@ def test_empty():
     assert "branch_length" not in result.columns
     assert "id" in result.columns
     assert len(result) == 0
+
+
+@pytest.mark.parametrize("col", sorted(_insert_insensitive_cols))
+def test_insert_only_preserves_insert_insensitive(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_drop_topological_sensitivity_polars(
+        df, insert=True, delete=False, update=False,
+    )
+    assert col in result.columns
+
+
+@pytest.mark.parametrize(
+    "col",
+    sorted(_topologically_sensitive_cols - _insert_insensitive_cols),
+)
+def test_insert_only_drops_insert_sensitive(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_drop_topological_sensitivity_polars(
+        df, insert=True, delete=False, update=False,
+    )
+    assert col not in result.columns
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_delete_drops_all(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_drop_topological_sensitivity_polars(
+        df, insert=False, delete=True, update=False,
+    )
+    assert col not in result.columns
+
+
+@pytest.mark.parametrize("col", sorted(_topologically_sensitive_cols))
+def test_update_drops_all(base_df, col):
+    df = base_df.with_columns(pl.lit(0).alias(col))
+    result = alifestd_drop_topological_sensitivity_polars(
+        df, insert=False, delete=False, update=True,
+    )
+    assert col not in result.columns
+
+
+def test_no_ops_drops_nothing(base_df):
+    df = base_df.with_columns(
+        pl.lit(0.0).alias("branch_length"),
+        pl.lit(0).alias("sister_id"),
+    )
+    result = alifestd_drop_topological_sensitivity_polars(
+        df, insert=False, delete=False, update=False,
+    )
+    assert "branch_length" in result.columns
+    assert "sister_id" in result.columns


### PR DESCRIPTION
## Summary
Expanded the warning in `alifestd_collapse_unifurcations` functions to alert users about all topology-dependent columns that may be invalidated by the operation, not just branch length columns.

## Key Changes
- **Expanded warned columns list**: Increased from 3 columns (`branch_length`, `edge_length`, `origin_time_delta`) to 34 topology-dependent columns including:
  - Structural columns: `is_left_child`, `is_right_child`, `left_child_id`, `right_child_id`, `sister_id`, `num_children`
  - Descendant-related columns: `num_descendants`, `num_leaves`, `num_leaves_sibling`, `num_preceding_leaves`
  - Time-related columns: `ancestor_origin_time`, `max_descendant_origin_time`, `node_depth`, `clade_subtended_duration`
  - Ratio and growth columns: `clade_duration_ratio_sister`, `clade_leafcount_ratio_sister`, `clade_nodecount_ratio_sister`, `clade_fblr_growth_children`, `clade_fblr_growth_sister`, `clade_logistic_growth_children`, `clade_logistic_growth_sister`
  - Other topology-dependent columns: `clade_duration`, `clade_faithpd`, `ot_mrca_id`, `ot_mrca_time_of`, `ot_mrca_time_since`

- **Improved warning message**: Changed from generic "branch length columns" to "topology-dependent columns, which may be invalidated" with explicit list of affected columns present in the dataframe

- **Applied to both implementations**: Updated both the standard pandas-based implementation and the Polars-based implementation consistently

## Implementation Details
- Refactored the column checking logic to use a list comprehension that filters warned columns against present columns, making the code more maintainable
- The warning now dynamically displays only the columns that are actually present in the input dataframe, providing more targeted feedback to users

https://claude.ai/code/session_01FbW377fj75oBUB6WPGguHQ