### PR TITLE
Add alifestd_add_global_root function to auxiliary library

### DIFF
--- a/hstrat/__main__.py
+++ b/hstrat/__main__.py
@@ -10,6 +10,7 @@ $ python3 -m hstrat.dataframe.surface_unpack_reconstruct
 $ python3 -m hstrat.dataframe.surface_postprocess_trie
 
 Available commands (experimental API):
+$ python3 -m hstrat._auxiliary_lib._alifestd_add_global_root
 $ python3 -m hstrat._auxiliary_lib._alifestd_add_inner_leaves
 $ python3 -m hstrat._auxiliary_lib._alifestd_as_newick_asexual
 $ python3 -m hstrat._auxiliary_lib._alifestd_collapse_unifurcations

--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -331,6 +331,7 @@ from ._delegate_polars_implementation import delegate_polars_implementation
 from ._demark import demark
 from ._div_range import div_range
 from ._estimate_binomial_p import estimate_binomial_p
+from ._eval_kwargs import eval_kwargs
 from ._except_wrap_sentinel import except_wrap_sentinel
 from ._fill_zeros_with_last import fill_zeros_with_last
 from ._find_bounds import find_bounds
@@ -602,6 +603,7 @@ __all__ = [
     "demark",
     "div_range",
     "estimate_binomial_p",
+    "eval_kwargs",
     "except_wrap_sentinel",
     "fill_zeros_with_last",
     "find_bounds",

--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -13,6 +13,7 @@ from ._HereditaryStratigraphicInstrument import (
 from ._RecursionLimit import RecursionLimit
 from ._RngStateContext import RngStateContext
 from ._ScalarFormatterFixedPrecision import ScalarFormatterFixedPrecision
+from ._alifestd_add_global_root import alifestd_add_global_root
 from ._alifestd_add_inner_knuckles_asexual import (
     alifestd_add_inner_knuckles_asexual,
 )
@@ -424,6 +425,7 @@ from ._with_rng_state_context import with_rng_state_context
 from ._zip_strict import zip_strict
 
 __all__ = [
+    "alifestd_add_global_root",
     "alifestd_add_inner_knuckles_asexual",
     "alifestd_add_inner_leaves",
     "alifestd_add_inner_niblings_asexual",

--- a/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
@@ -1,0 +1,118 @@
+import typing
+import warnings
+
+import pandas as pd
+
+from ._alifestd_find_root_ids import alifestd_find_root_ids
+
+
+_warned_columns = (
+    "ancestor_origin_time",
+    "branch_length",
+    "clade_duration",
+    "clade_duration_ratio_sister",
+    "clade_fblr_growth_children",
+    "clade_fblr_growth_sister",
+    "clade_faithpd",
+    "clade_leafcount_ratio_sister",
+    "clade_logistic_growth_children",
+    "clade_logistic_growth_sister",
+    "clade_nodecount_ratio_sister",
+    "clade_subtended_duration",
+    "clade_subtended_duration_ratio_sister",
+    "edge_length",
+    "is_left_child",
+    "is_right_child",
+    "left_child_id",
+    "max_descendant_origin_time",
+    "node_depth",
+    "num_children",
+    "num_descendants",
+    "num_leaves",
+    "num_leaves_sibling",
+    "num_preceding_leaves",
+    "origin_time_delta",
+    "ot_mrca_id",
+    "ot_mrca_time_of",
+    "ot_mrca_time_since",
+    "right_child_id",
+    "sister_id",
+)
+
+
+def alifestd_add_global_root(
+    phylogeny_df: pd.DataFrame,
+    mutate: bool = False,
+    origin_time: typing.Optional[float] = None,
+) -> pd.DataFrame:
+    """Add a new global root node that all existing roots point to.
+
+    The new root node will only have columns `id`, `ancestor_id` (if
+    applicable), `ancestor_list` (if applicable), and `origin_time` (if
+    applicable). All other columns will be NaN for the new root row.
+
+    Parameters
+    ----------
+    phylogeny_df : pd.DataFrame
+        Phylogeny dataframe in alife standard format.
+    mutate : bool, default False
+        If True, allows mutation of the input dataframe.
+    origin_time : float or None, default None
+        If provided, sets the `origin_time` of the new global root node.
+
+    Returns
+    -------
+    pd.DataFrame
+        The phylogeny dataframe with a new global root added.
+
+    Input dataframe is not mutated by this operation unless `mutate` set True.
+    If mutate set True, operation does not occur in place; still use return
+    value to get transformed phylogeny dataframe.
+    """
+    if not mutate:
+        phylogeny_df = phylogeny_df.copy()
+
+    if len(phylogeny_df) == 0:
+        return phylogeny_df
+
+    # Warn about columns that may become invalid
+    present_warned = [
+        col for col in _warned_columns if col in phylogeny_df
+    ]
+    if present_warned:
+        warnings.warn(
+            "alifestd_add_global_root does not update columns "
+            f"{present_warned}. These columns may become invalid after "
+            "adding a global root."
+        )
+
+    # Create new root id
+    new_root_id = phylogeny_df["id"].max() + 1
+
+    # Build the new root row with only applicable columns
+    new_root = {"id": new_root_id}
+
+    if "ancestor_id" in phylogeny_df:
+        new_root["ancestor_id"] = new_root_id
+
+    if "ancestor_list" in phylogeny_df:
+        new_root["ancestor_list"] = "[none]"
+
+    if origin_time is not None:
+        new_root["origin_time"] = origin_time
+
+    # Point existing roots to the new global root
+    root_ids = alifestd_find_root_ids(phylogeny_df)
+    root_mask = phylogeny_df["id"].isin(root_ids)
+
+    if "ancestor_id" in phylogeny_df:
+        phylogeny_df.loc[root_mask, "ancestor_id"] = new_root_id
+
+    if "ancestor_list" in phylogeny_df:
+        phylogeny_df.loc[root_mask, "ancestor_list"] = f"[{new_root_id}]"
+
+    # Append the new root row
+    new_root_df = pd.DataFrame([new_root])
+    res = pd.concat([phylogeny_df, new_root_df], ignore_index=True)
+
+    return res

--- a/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
@@ -111,8 +111,8 @@ def alifestd_add_global_root(
     if "ancestor_list" in phylogeny_df:
         phylogeny_df.loc[root_mask, "ancestor_list"] = f"[{new_root_id}]"
 
-    # Append the new root row
+    # Append the new root row (vertical concat; mismatched columns get NaN)
     new_root_df = pd.DataFrame([new_root])
-    res = pd.concat([phylogeny_df, new_root_df], ignore_index=True)
+    res = pd.concat([phylogeny_df, new_root_df], axis=0, ignore_index=True)
 
     return res

--- a/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
@@ -1,43 +1,11 @@
 import types
 import typing
-import warnings
 
 import pandas as pd
 
 from ._alifestd_find_root_ids import alifestd_find_root_ids
-
-
-_warned_columns = (
-    "ancestor_origin_time",
-    "branch_length",
-    "clade_duration",
-    "clade_duration_ratio_sister",
-    "clade_fblr_growth_children",
-    "clade_fblr_growth_sister",
-    "clade_faithpd",
-    "clade_leafcount_ratio_sister",
-    "clade_logistic_growth_children",
-    "clade_logistic_growth_sister",
-    "clade_nodecount_ratio_sister",
-    "clade_subtended_duration",
-    "clade_subtended_duration_ratio_sister",
-    "edge_length",
-    "is_left_child",
-    "is_right_child",
-    "left_child_id",
-    "max_descendant_origin_time",
-    "node_depth",
-    "num_children",
-    "num_descendants",
-    "num_leaves",
-    "num_leaves_sibling",
-    "num_preceding_leaves",
-    "origin_time_delta",
-    "ot_mrca_id",
-    "ot_mrca_time_of",
-    "ot_mrca_time_since",
-    "right_child_id",
-    "sister_id",
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
 )
 
 
@@ -58,7 +26,7 @@ def alifestd_add_global_root(
         Phylogeny dataframe in alife standard format.
     mutate : bool, default False
         If True, allows mutation of the input dataframe.
-    root_attrs : Mapping[str, Any], default frozendict()
+    root_attrs : Mapping[str, Any], default {}
         Column values to set on the new global root row, e.g.,
         ``{"origin_time": 0.0, "taxon_label": "root"}``.
 
@@ -77,16 +45,13 @@ def alifestd_add_global_root(
     if len(phylogeny_df) == 0:
         return phylogeny_df
 
-    # Warn about columns that may become invalid
-    present_warned = [
-        col for col in _warned_columns if col in phylogeny_df
-    ]
-    if present_warned:
-        warnings.warn(
-            "alifestd_add_global_root does not update columns "
-            f"{present_warned}. These columns may become invalid after "
-            "adding a global root."
-        )
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_add_global_root",
+        insert=True,
+        delete=False,
+        update=True,
+    )
 
     # Create new root id
     new_root_id = phylogeny_df["id"].max() + 1

--- a/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
@@ -1,3 +1,4 @@
+import types
 import typing
 import warnings
 
@@ -43,13 +44,13 @@ _warned_columns = (
 def alifestd_add_global_root(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
-    origin_time: typing.Optional[float] = None,
+    root_attrs: typing.Mapping[str, typing.Any] = types.MappingProxyType({}),
 ) -> pd.DataFrame:
     """Add a new global root node that all existing roots point to.
 
-    The new root node will only have columns `id`, `ancestor_id` (if
-    applicable), `ancestor_list` (if applicable), and `origin_time` (if
-    applicable). All other columns will be NaN for the new root row.
+    The new root node will have columns `id`, `ancestor_id` (if applicable),
+    `ancestor_list` (if applicable), and any columns specified in
+    `root_attrs`. All other columns will be NaN for the new root row.
 
     Parameters
     ----------
@@ -57,8 +58,9 @@ def alifestd_add_global_root(
         Phylogeny dataframe in alife standard format.
     mutate : bool, default False
         If True, allows mutation of the input dataframe.
-    origin_time : float or None, default None
-        If provided, sets the `origin_time` of the new global root node.
+    root_attrs : Mapping[str, Any], default frozendict()
+        Column values to set on the new global root row, e.g.,
+        ``{"origin_time": 0.0, "taxon_label": "root"}``.
 
     Returns
     -------
@@ -98,8 +100,7 @@ def alifestd_add_global_root(
     if "ancestor_list" in phylogeny_df:
         new_root["ancestor_list"] = "[none]"
 
-    if origin_time is not None:
-        new_root["origin_time"] = origin_time
+    new_root.update(root_attrs)
 
     # Point existing roots to the new global root
     root_ids = alifestd_find_root_ids(phylogeny_df)

--- a/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
@@ -78,11 +78,7 @@ def alifestd_add_global_root(
     )
 
     # Create new root id
-    new_root_id = (
-        phylogeny_df["id"].max() + 1
-        if not phylogeny_df.empty
-        else 0
-    )
+    new_root_id = phylogeny_df["id"].max() + 1 if not phylogeny_df.empty else 0
 
     # Build the new root row
     new_root = {

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
@@ -2,7 +2,6 @@ import argparse
 import logging
 import os
 import pathlib
-import sys
 import typing
 
 import more_itertools as mit
@@ -21,24 +20,10 @@ from ._alifestd_unfurl_traversal_postorder_asexual import (
     alifestd_unfurl_traversal_postorder_asexual,
 )
 from ._configure_prod_logging import configure_prod_logging
+from ._eval_kwargs import eval_kwargs
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
 from ._log_context_duration import log_context_duration
-
-
-def _eval_kwargs(kwargs_list: typing.List[str]) -> typing.Dict:
-    # adapted from https://github.com/mmore500/joinem/blob/v0.11.1/joinem/_dataframe_cli.py#L120
-    to_eval = f"dict({','.join(kwargs_list)})"
-    try:
-        return eval(to_eval)
-    except Exception as e:
-        logging.error(
-            "Failed to parse kwarg expressions `%s` via `%s`" " error: %s",
-            kwargs_list,
-            to_eval,
-            e,
-        )
-        sys.exit(1)
 
 
 # adapted from https://stackoverflow.com/a/3939381/17332200
@@ -247,7 +232,7 @@ if __name__ == "__main__":
     )
     phylogeny_df = dispatch_reader[f"{args.input_engine}+{input_ext}"](
         args.input_file,
-        **_eval_kwargs(args.input_kwargs),
+        **eval_kwargs(args.input_kwargs),
     )
 
     if args.input_engine == "polars":

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
@@ -25,7 +25,6 @@ from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
 from ._log_context_duration import log_context_duration
 
-
 # adapted from https://stackoverflow.com/a/3939381/17332200
 _UNSAFE_SYMBOLS = ";(),[]:'"
 _UNSAFE_TRANSLATION_TABLE = str.maketrans("", "", _UNSAFE_SYMBOLS)

--- a/hstrat/_auxiliary_lib/_eval_kwargs.py
+++ b/hstrat/_auxiliary_lib/_eval_kwargs.py
@@ -23,5 +23,5 @@ def eval_kwargs(kwargs_list: typing.List[str]) -> typing.Dict:
     except Exception as e:
         raise ValueError(
             f"Failed to parse kwarg expressions {kwargs_list!r} "
-            f"via {to_eval!r}"
+            f"via {to_eval!r}",
         ) from e

--- a/hstrat/_auxiliary_lib/_eval_kwargs.py
+++ b/hstrat/_auxiliary_lib/_eval_kwargs.py
@@ -1,0 +1,32 @@
+import logging
+import sys
+import typing
+
+
+# adapted from https://github.com/mmore500/joinem/blob/v0.11.1/joinem/_dataframe_cli.py#L120
+def eval_kwargs(kwargs_list: typing.List[str]) -> typing.Dict:
+    """Parse a list of 'key=value' strings into a dictionary.
+
+    Values are evaluated as Python expressions.
+
+    Parameters
+    ----------
+    kwargs_list : list of str
+        Each element should be a 'key=value' string.
+
+    Returns
+    -------
+    dict
+        Parsed keyword arguments.
+    """
+    to_eval = f"dict({','.join(kwargs_list)})"
+    try:
+        return eval(to_eval)
+    except Exception as e:
+        logging.error(
+            "Failed to parse kwarg expressions `%s` via `%s`" " error: %s",
+            kwargs_list,
+            to_eval,
+            e,
+        )
+        sys.exit(1)

--- a/hstrat/_auxiliary_lib/_eval_kwargs.py
+++ b/hstrat/_auxiliary_lib/_eval_kwargs.py
@@ -1,5 +1,3 @@
-import logging
-import sys
 import typing
 
 
@@ -23,10 +21,7 @@ def eval_kwargs(kwargs_list: typing.List[str]) -> typing.Dict:
     try:
         return eval(to_eval)
     except Exception as e:
-        logging.error(
-            "Failed to parse kwarg expressions `%s` via `%s`" " error: %s",
-            kwargs_list,
-            to_eval,
-            e,
-        )
-        sys.exit(1)
+        raise ValueError(
+            f"Failed to parse kwarg expressions {kwargs_list!r} "
+            f"via {to_eval!r}"
+        ) from e

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root.py
@@ -422,12 +422,17 @@ def test_root_attrs_empty_with_existing_column(mutate: bool):
     assert pd.isna(root_row["origin_time"])
 
 
-def test_warns_on_branch_length_columns():
+@pytest.mark.parametrize(
+    "col",
+    ["branch_length", "edge_length", "origin_time_delta", "node_depth",
+     "num_descendants", "num_children", "num_leaves"],
+)
+def test_warns_on_sensitive_column(col: str):
     phylogeny_df = pd.DataFrame(
         {
             "id": [0, 1],
             "ancestor_list": ["[none]", "[0]"],
-            "branch_length": [0.0, 1.0],
+            col: [0.0, 1.0],
         }
     )
 
@@ -435,55 +440,9 @@ def test_warns_on_branch_length_columns():
         warnings.simplefilter("always")
         alifestd_add_global_root(phylogeny_df)
         assert len(w) == 1
-        assert "branch_length" in str(w[0].message)
-
-
-def test_warns_on_edge_length_columns():
-    phylogeny_df = pd.DataFrame(
-        {
-            "id": [0, 1],
-            "ancestor_list": ["[none]", "[0]"],
-            "edge_length": [0.0, 1.0],
-        }
-    )
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        alifestd_add_global_root(phylogeny_df)
-        assert len(w) == 1
-        assert "edge_length" in str(w[0].message)
-
-
-def test_warns_on_origin_time_delta():
-    phylogeny_df = pd.DataFrame(
-        {
-            "id": [0, 1],
-            "ancestor_list": ["[none]", "[0]"],
-            "origin_time_delta": [0.0, 1.0],
-        }
-    )
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        alifestd_add_global_root(phylogeny_df)
-        assert len(w) == 1
-        assert "origin_time_delta" in str(w[0].message)
-
-
-def test_warns_on_node_depth():
-    phylogeny_df = pd.DataFrame(
-        {
-            "id": [0, 1],
-            "ancestor_list": ["[none]", "[0]"],
-            "node_depth": [0, 1],
-        }
-    )
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        alifestd_add_global_root(phylogeny_df)
-        assert len(w) == 1
-        assert "node_depth" in str(w[0].message)
+        msg = str(w[0].message)
+        assert col in msg
+        assert "topology-dependent" in msg
 
 
 def test_warns_on_multiple_columns():

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root.py
@@ -1,0 +1,433 @@
+import warnings
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from hstrat._auxiliary_lib import (
+    alifestd_add_global_root,
+    alifestd_find_root_ids,
+    alifestd_make_empty,
+    alifestd_validate,
+)
+
+
+def test_empty():
+    res = alifestd_add_global_root(alifestd_make_empty())
+    assert len(res) == 0
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_single_root_ancestor_list(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_list": ["[none]", "[0]", "[0]"],
+        }
+    )
+    original_df = phylogeny_df.copy()
+
+    result_df = alifestd_add_global_root(phylogeny_df, mutate=mutate)
+
+    assert len(result_df) == 4
+    assert alifestd_validate(result_df)
+
+    root_ids = alifestd_find_root_ids(result_df)
+    assert len(root_ids) == 1
+
+    new_root_id = result_df["id"].max()
+    assert new_root_id == 3
+    root_row = result_df[result_df["id"] == new_root_id].iloc[0]
+    assert root_row["ancestor_list"] == "[none]"
+
+    # Old root should now point to new root
+    old_root = result_df[result_df["id"] == 0].iloc[0]
+    assert old_root["ancestor_list"] == f"[{new_root_id}]"
+
+    if not mutate:
+        assert original_df.equals(phylogeny_df)
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_single_root_ancestor_id(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_id": [0, 0, 0],
+            "ancestor_list": ["[none]", "[0]", "[0]"],
+        }
+    )
+    original_df = phylogeny_df.copy()
+
+    result_df = alifestd_add_global_root(phylogeny_df, mutate=mutate)
+
+    assert len(result_df) == 4
+    assert alifestd_validate(result_df)
+
+    new_root_id = result_df["id"].max()
+    assert new_root_id == 3
+
+    root_row = result_df[result_df["id"] == new_root_id].iloc[0]
+    assert root_row["ancestor_id"] == new_root_id
+    assert root_row["ancestor_list"] == "[none]"
+
+    # Old root should now point to new root
+    old_root = result_df[result_df["id"] == 0].iloc[0]
+    assert old_root["ancestor_id"] == new_root_id
+    assert old_root["ancestor_list"] == f"[{new_root_id}]"
+
+    if not mutate:
+        assert original_df.equals(phylogeny_df)
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_multiple_roots(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2, 3],
+            "ancestor_list": ["[none]", "[0]", "[none]", "[2]"],
+        }
+    )
+    original_df = phylogeny_df.copy()
+
+    result_df = alifestd_add_global_root(phylogeny_df, mutate=mutate)
+
+    assert len(result_df) == 5
+    assert alifestd_validate(result_df)
+
+    root_ids = alifestd_find_root_ids(result_df)
+    assert len(root_ids) == 1
+
+    new_root_id = result_df["id"].max()
+    assert new_root_id == 4
+
+    # Both old roots should point to new root
+    old_root_0 = result_df[result_df["id"] == 0].iloc[0]
+    old_root_2 = result_df[result_df["id"] == 2].iloc[0]
+    assert old_root_0["ancestor_list"] == f"[{new_root_id}]"
+    assert old_root_2["ancestor_list"] == f"[{new_root_id}]"
+
+    # Non-root nodes should be unchanged
+    node_1 = result_df[result_df["id"] == 1].iloc[0]
+    node_3 = result_df[result_df["id"] == 3].iloc[0]
+    assert node_1["ancestor_list"] == "[0]"
+    assert node_3["ancestor_list"] == "[2]"
+
+    if not mutate:
+        assert original_df.equals(phylogeny_df)
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_multiple_roots_ancestor_id(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2, 3],
+            "ancestor_id": [0, 0, 2, 2],
+            "ancestor_list": ["[none]", "[0]", "[none]", "[2]"],
+        }
+    )
+    original_df = phylogeny_df.copy()
+
+    result_df = alifestd_add_global_root(phylogeny_df, mutate=mutate)
+
+    assert len(result_df) == 5
+    assert alifestd_validate(result_df)
+
+    new_root_id = result_df["id"].max()
+
+    old_root_0 = result_df[result_df["id"] == 0].iloc[0]
+    old_root_2 = result_df[result_df["id"] == 2].iloc[0]
+    assert old_root_0["ancestor_id"] == new_root_id
+    assert old_root_2["ancestor_id"] == new_root_id
+
+    # Non-root nodes unchanged
+    node_1 = result_df[result_df["id"] == 1].iloc[0]
+    assert node_1["ancestor_id"] == 0
+
+    if not mutate:
+        assert original_df.equals(phylogeny_df)
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_origin_time_kwarg(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+            "origin_time": [10, 20],
+        }
+    )
+
+    result_df = alifestd_add_global_root(
+        phylogeny_df, mutate=mutate, origin_time=5,
+    )
+
+    assert len(result_df) == 3
+    new_root_id = result_df["id"].max()
+    root_row = result_df[result_df["id"] == new_root_id].iloc[0]
+    assert root_row["origin_time"] == 5
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_origin_time_kwarg_no_column(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+        }
+    )
+
+    result_df = alifestd_add_global_root(
+        phylogeny_df, mutate=mutate, origin_time=5,
+    )
+
+    assert len(result_df) == 3
+    new_root_id = result_df["id"].max()
+    root_row = result_df[result_df["id"] == new_root_id].iloc[0]
+    assert root_row["origin_time"] == 5
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_origin_time_none_no_column(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+        }
+    )
+
+    result_df = alifestd_add_global_root(phylogeny_df, mutate=mutate)
+
+    assert len(result_df) == 3
+    assert "origin_time" not in result_df.columns
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_origin_time_none_with_column(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+            "origin_time": [10, 20],
+        }
+    )
+
+    result_df = alifestd_add_global_root(phylogeny_df, mutate=mutate)
+
+    assert len(result_df) == 3
+    new_root_id = result_df["id"].max()
+    root_row = result_df[result_df["id"] == new_root_id].iloc[0]
+    # origin_time not set when kwarg is None, so NaN from concat
+    assert pd.isna(root_row["origin_time"])
+
+
+def test_warns_on_branch_length_columns():
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+            "branch_length": [0.0, 1.0],
+        }
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_add_global_root(phylogeny_df)
+        assert len(w) == 1
+        assert "branch_length" in str(w[0].message)
+
+
+def test_warns_on_edge_length_columns():
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+            "edge_length": [0.0, 1.0],
+        }
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_add_global_root(phylogeny_df)
+        assert len(w) == 1
+        assert "edge_length" in str(w[0].message)
+
+
+def test_warns_on_origin_time_delta():
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+            "origin_time_delta": [0.0, 1.0],
+        }
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_add_global_root(phylogeny_df)
+        assert len(w) == 1
+        assert "origin_time_delta" in str(w[0].message)
+
+
+def test_warns_on_node_depth():
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+            "node_depth": [0, 1],
+        }
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_add_global_root(phylogeny_df)
+        assert len(w) == 1
+        assert "node_depth" in str(w[0].message)
+
+
+def test_warns_on_multiple_columns():
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+            "branch_length": [0.0, 1.0],
+            "edge_length": [0.0, 1.0],
+            "num_descendants": [1, 0],
+        }
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_add_global_root(phylogeny_df)
+        assert len(w) == 1
+        msg = str(w[0].message)
+        assert "branch_length" in msg
+        assert "edge_length" in msg
+        assert "num_descendants" in msg
+
+
+def test_no_warning_without_warned_columns():
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+        }
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alifestd_add_global_root(phylogeny_df)
+        assert len(w) == 0
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_new_root_has_only_applicable_columns(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_id": [0, 0],
+            "ancestor_list": ["[none]", "[0]"],
+            "origin_time": [0, 1],
+            "taxon_label": ["A", "B"],
+            "some_extra_col": [42, 99],
+        }
+    )
+
+    result_df = alifestd_add_global_root(
+        phylogeny_df, mutate=mutate, origin_time=0,
+    )
+
+    new_root_id = result_df["id"].max()
+    root_row = result_df[result_df["id"] == new_root_id].iloc[0]
+
+    # These should be set
+    assert root_row["id"] == new_root_id
+    assert root_row["ancestor_id"] == new_root_id
+    assert root_row["ancestor_list"] == "[none]"
+    assert root_row["origin_time"] == 0
+
+    # These should be NaN
+    assert pd.isna(root_row["taxon_label"])
+    assert pd.isna(root_row["some_extra_col"])
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_noncontiguous_ids(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [5, 10, 15],
+            "ancestor_id": [5, 5, 10],
+            "ancestor_list": ["[none]", "[5]", "[10]"],
+        }
+    )
+    original_df = phylogeny_df.copy()
+
+    result_df = alifestd_add_global_root(phylogeny_df, mutate=mutate)
+
+    assert len(result_df) == 4
+    assert alifestd_validate(result_df)
+
+    new_root_id = result_df["id"].max()
+    assert new_root_id == 16
+
+    root_ids = alifestd_find_root_ids(result_df)
+    assert len(root_ids) == 1
+    assert root_ids[0] == new_root_id
+
+    if not mutate:
+        assert original_df.equals(phylogeny_df)
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_ancestor_list_only(mutate: bool):
+    """Test with ancestor_list but no ancestor_id column."""
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_list": ["[none]", "[0]", "[none]"],
+        }
+    )
+    original_df = phylogeny_df.copy()
+
+    result_df = alifestd_add_global_root(phylogeny_df, mutate=mutate)
+
+    assert len(result_df) == 4
+    assert alifestd_validate(result_df)
+    assert "ancestor_id" not in result_df.columns
+
+    new_root_id = result_df["id"].max()
+    root_row = result_df[result_df["id"] == new_root_id].iloc[0]
+    assert root_row["ancestor_list"] == "[none]"
+
+    root_ids = alifestd_find_root_ids(result_df)
+    assert len(root_ids) == 1
+
+    if not mutate:
+        assert original_df.equals(phylogeny_df)
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_single_node(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0],
+            "ancestor_id": [0],
+            "ancestor_list": ["[none]"],
+        }
+    )
+    original_df = phylogeny_df.copy()
+
+    result_df = alifestd_add_global_root(phylogeny_df, mutate=mutate)
+
+    assert len(result_df) == 2
+    assert alifestd_validate(result_df)
+
+    new_root_id = result_df["id"].max()
+    assert new_root_id == 1
+
+    root_ids = alifestd_find_root_ids(result_df)
+    assert len(root_ids) == 1
+    assert root_ids[0] == new_root_id
+
+    if not mutate:
+        assert original_df.equals(phylogeny_df)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root.py
@@ -13,7 +13,41 @@ from hstrat._auxiliary_lib import (
 
 def test_empty():
     res = alifestd_add_global_root(alifestd_make_empty())
-    assert len(res) == 0
+    assert len(res) == 1
+    assert alifestd_validate(res)
+    root_ids = alifestd_find_root_ids(res)
+    assert len(root_ids) == 1
+    assert res.iloc[0]["id"] == 0
+    assert res.iloc[0]["ancestor_list"] == "[none]"
+
+
+def test_empty_with_ancestor_id():
+    res = alifestd_add_global_root(alifestd_make_empty(ancestor_id=True))
+    assert len(res) == 1
+    assert alifestd_validate(res)
+    assert res.iloc[0]["id"] == 0
+    assert res.iloc[0]["ancestor_id"] == 0
+    assert res.iloc[0]["ancestor_list"] == "[none]"
+
+
+def test_empty_with_root_attrs():
+    res = alifestd_add_global_root(
+        alifestd_make_empty(), root_attrs={"origin_time": 42.0},
+    )
+    assert len(res) == 1
+    assert res.iloc[0]["origin_time"] == 42.0
+
+
+@pytest.mark.parametrize("key", ["id", "ancestor_id", "ancestor_list"])
+def test_root_attrs_reserved_key_raises(key: str):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+        }
+    )
+    with pytest.raises(ValueError, match="reserved"):
+        alifestd_add_global_root(phylogeny_df, root_attrs={key: 999})
 
 
 @pytest.mark.parametrize("mutate", [False, True])

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root.py
@@ -326,7 +326,7 @@ def test_sexual_with_empty_bracket_roots(mutate: bool):
 
 
 @pytest.mark.parametrize("mutate", [False, True])
-def test_origin_time_kwarg(mutate: bool):
+def test_root_attrs_origin_time(mutate: bool):
     phylogeny_df = pd.DataFrame(
         {
             "id": [0, 1],
@@ -336,7 +336,7 @@ def test_origin_time_kwarg(mutate: bool):
     )
 
     result_df = alifestd_add_global_root(
-        phylogeny_df, mutate=mutate, origin_time=5,
+        phylogeny_df, mutate=mutate, root_attrs={"origin_time": 5},
     )
 
     assert len(result_df) == 3
@@ -346,7 +346,7 @@ def test_origin_time_kwarg(mutate: bool):
 
 
 @pytest.mark.parametrize("mutate", [False, True])
-def test_origin_time_kwarg_no_column(mutate: bool):
+def test_root_attrs_new_column(mutate: bool):
     phylogeny_df = pd.DataFrame(
         {
             "id": [0, 1],
@@ -355,7 +355,7 @@ def test_origin_time_kwarg_no_column(mutate: bool):
     )
 
     result_df = alifestd_add_global_root(
-        phylogeny_df, mutate=mutate, origin_time=5,
+        phylogeny_df, mutate=mutate, root_attrs={"origin_time": 5},
     )
 
     assert len(result_df) == 3
@@ -365,7 +365,31 @@ def test_origin_time_kwarg_no_column(mutate: bool):
 
 
 @pytest.mark.parametrize("mutate", [False, True])
-def test_origin_time_none_no_column(mutate: bool):
+def test_root_attrs_multiple(mutate: bool):
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1],
+            "ancestor_list": ["[none]", "[0]"],
+            "origin_time": [10, 20],
+            "taxon_label": ["A", "B"],
+        }
+    )
+
+    result_df = alifestd_add_global_root(
+        phylogeny_df,
+        mutate=mutate,
+        root_attrs={"origin_time": 0, "taxon_label": "root"},
+    )
+
+    assert len(result_df) == 3
+    new_root_id = result_df["id"].max()
+    root_row = result_df[result_df["id"] == new_root_id].iloc[0]
+    assert root_row["origin_time"] == 0
+    assert root_row["taxon_label"] == "root"
+
+
+@pytest.mark.parametrize("mutate", [False, True])
+def test_root_attrs_empty(mutate: bool):
     phylogeny_df = pd.DataFrame(
         {
             "id": [0, 1],
@@ -380,7 +404,7 @@ def test_origin_time_none_no_column(mutate: bool):
 
 
 @pytest.mark.parametrize("mutate", [False, True])
-def test_origin_time_none_with_column(mutate: bool):
+def test_root_attrs_empty_with_existing_column(mutate: bool):
     phylogeny_df = pd.DataFrame(
         {
             "id": [0, 1],
@@ -394,7 +418,7 @@ def test_origin_time_none_with_column(mutate: bool):
     assert len(result_df) == 3
     new_root_id = result_df["id"].max()
     root_row = result_df[result_df["id"] == new_root_id].iloc[0]
-    # origin_time not set when kwarg is None, so NaN from concat
+    # origin_time not in root_attrs, so NaN from concat
     assert pd.isna(root_row["origin_time"])
 
 
@@ -511,7 +535,7 @@ def test_new_root_has_only_applicable_columns(mutate: bool):
     )
 
     result_df = alifestd_add_global_root(
-        phylogeny_df, mutate=mutate, origin_time=0,
+        phylogeny_df, mutate=mutate, root_attrs={"origin_time": 0},
     )
 
     new_root_id = result_df["id"].max()

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root.py
@@ -32,7 +32,8 @@ def test_empty_with_ancestor_id():
 
 def test_empty_with_root_attrs():
     res = alifestd_add_global_root(
-        alifestd_make_empty(), root_attrs={"origin_time": 42.0},
+        alifestd_make_empty(),
+        root_attrs={"origin_time": 42.0},
     )
     assert len(res) == 1
     assert res.iloc[0]["origin_time"] == 42.0
@@ -370,7 +371,9 @@ def test_root_attrs_origin_time(mutate: bool):
     )
 
     result_df = alifestd_add_global_root(
-        phylogeny_df, mutate=mutate, root_attrs={"origin_time": 5},
+        phylogeny_df,
+        mutate=mutate,
+        root_attrs={"origin_time": 5},
     )
 
     assert len(result_df) == 3
@@ -389,7 +392,9 @@ def test_root_attrs_new_column(mutate: bool):
     )
 
     result_df = alifestd_add_global_root(
-        phylogeny_df, mutate=mutate, root_attrs={"origin_time": 5},
+        phylogeny_df,
+        mutate=mutate,
+        root_attrs={"origin_time": 5},
     )
 
     assert len(result_df) == 3
@@ -458,8 +463,15 @@ def test_root_attrs_empty_with_existing_column(mutate: bool):
 
 @pytest.mark.parametrize(
     "col",
-    ["branch_length", "edge_length", "origin_time_delta", "node_depth",
-     "num_descendants", "num_children", "num_leaves"],
+    [
+        "branch_length",
+        "edge_length",
+        "origin_time_delta",
+        "node_depth",
+        "num_descendants",
+        "num_children",
+        "num_leaves",
+    ],
 )
 def test_warns_on_sensitive_column(col: str):
     phylogeny_df = pd.DataFrame(
@@ -528,7 +540,9 @@ def test_new_root_has_only_applicable_columns(mutate: bool):
     )
 
     result_df = alifestd_add_global_root(
-        phylogeny_df, mutate=mutate, root_attrs={"origin_time": 0},
+        phylogeny_df,
+        mutate=mutate,
+        root_attrs={"origin_time": 0},
     )
 
     new_root_id = result_df["id"].max()

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root_cli.py
@@ -1,0 +1,60 @@
+import os
+import subprocess
+
+assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
+
+
+def test_alifestd_add_global_root_cli_help():
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_add_global_root",
+            "--help",
+        ],
+        check=True,
+    )
+
+
+def test_alifestd_add_global_root_cli_version():
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_add_global_root",
+            "--version",
+        ],
+        check=True,
+    )
+
+
+def test_alifestd_add_global_root_cli_csv(tmp_path):
+    output_file = str(tmp_path / "hstrat_alifestd_add_global_root.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_add_global_root",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_add_global_root_cli_parquet(tmp_path):
+    output_file = str(tmp_path / "hstrat_alifestd_add_global_root.pqt")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_add_global_root",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_eval_kwargs.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_eval_kwargs.py
@@ -35,6 +35,6 @@ def test_bool():
     assert eval_kwargs(["flag=False"]) == {"flag": False}
 
 
-def test_invalid_exits():
-    with pytest.raises(SystemExit):
+def test_invalid_raises():
+    with pytest.raises(ValueError, match="Failed to parse"):
         eval_kwargs(["not valid python!!!"])

--- a/tests/test_hstrat/test_auxiliary_lib/test_eval_kwargs.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_eval_kwargs.py
@@ -1,0 +1,40 @@
+import pytest
+
+from hstrat._auxiliary_lib import eval_kwargs
+
+
+def test_empty():
+    assert eval_kwargs([]) == {}
+
+
+def test_single_string():
+    assert eval_kwargs(["key='value'"]) == {"key": "value"}
+
+
+def test_single_int():
+    assert eval_kwargs(["x=42"]) == {"x": 42}
+
+
+def test_single_float():
+    assert eval_kwargs(["origin_time=0.0"]) == {"origin_time": 0.0}
+
+
+def test_single_none():
+    assert eval_kwargs(["infer_schema_length=None"]) == {
+        "infer_schema_length": None,
+    }
+
+
+def test_multiple():
+    result = eval_kwargs(["x=1", "y='hello'", "z=None"])
+    assert result == {"x": 1, "y": "hello", "z": None}
+
+
+def test_bool():
+    assert eval_kwargs(["flag=True"]) == {"flag": True}
+    assert eval_kwargs(["flag=False"]) == {"flag": False}
+
+
+def test_invalid_exits(monkeypatch):
+    with pytest.raises(SystemExit):
+        eval_kwargs(["not valid python!!!"])

--- a/tests/test_hstrat/test_auxiliary_lib/test_eval_kwargs.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_eval_kwargs.py
@@ -35,6 +35,6 @@ def test_bool():
     assert eval_kwargs(["flag=False"]) == {"flag": False}
 
 
-def test_invalid_exits(monkeypatch):
+def test_invalid_exits():
     with pytest.raises(SystemExit):
         eval_kwargs(["not valid python!!!"])


### PR DESCRIPTION
## Summary
This PR adds a new utility function `alifestd_add_global_root` to the auxiliary library for manipulating phylogeny dataframes in alife standard format. The function adds a new global root node that all existing root nodes point to, enabling conversion of multi-root phylogenies into single-root phylogenies.

## Key Changes
- **New function `alifestd_add_global_root`**: Adds a synthetic global root node to a phylogeny dataframe
  - Creates a new root node with ID one greater than the maximum existing ID
  - Updates all existing root nodes to point to the new global root via `ancestor_id` and/or `ancestor_list` columns
  - Supports optional `origin_time` parameter for setting the new root's origin time
  - Includes `mutate` parameter to control whether the input dataframe is modified
  - Only populates applicable columns (`id`, `ancestor_id`, `ancestor_list`, `origin_time`) in the new root row; other columns are NaN

- **Comprehensive test suite** with 30+ test cases covering:
  - Empty dataframes
  - Single and multiple root scenarios
  - Both `ancestor_id` and `ancestor_list` column formats
  - `origin_time` parameter handling
  - Non-contiguous ID values
  - Mutation behavior (mutate=True/False)
  - Warning generation for columns that may become invalid (branch_length, edge_length, node_depth, etc.)
  - Edge cases like single-node phylogenies

## Implementation Details
- The function warns users when columns that may become invalid after adding a global root are present (e.g., `branch_length`, `edge_length`, `node_depth`, `num_descendants`, etc.)
- Uses `alifestd_find_root_ids` to identify existing root nodes
- Leverages pandas operations for efficient dataframe manipulation
- Maintains dataframe immutability by default (only mutates when explicitly requested)
- Validates output using `alifestd_validate` in tests

https://claude.ai/code/session_01AXbrSTa2EbkaaZo7RibWj9