### PR TITLE
Add alifestd_warn_topological_sensitivity to all topology-modifying functions

### DIFF
--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -259,13 +259,13 @@ from ._alifestd_test_leaves_isomorphic_asexual import (
     alifestd_test_leaves_isomorphic_asexual,
 )
 from ._alifestd_to_working_format import alifestd_to_working_format
-from ._alifestd_topological_sort import alifestd_topological_sort
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
 from ._alifestd_topological_sensitivity_warned_polars import (
     alifestd_topological_sensitivity_warned_polars,
 )
+from ._alifestd_topological_sort import alifestd_topological_sort
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_try_add_ancestor_id_col_polars import (
     alifestd_try_add_ancestor_id_col_polars,
@@ -548,9 +548,9 @@ __all__ = [
     "alifestd_sum_origin_time_deltas_asexual",
     "alifestd_test_leaves_isomorphic_asexual",
     "alifestd_to_working_format",
-    "alifestd_topological_sort",
     "alifestd_topological_sensitivity_warned",
     "alifestd_topological_sensitivity_warned_polars",
+    "alifestd_topological_sort",
     "alifestd_try_add_ancestor_id_col",
     "alifestd_try_add_ancestor_id_col_polars",
     "alifestd_try_add_ancestor_list_col",

--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -260,6 +260,12 @@ from ._alifestd_test_leaves_isomorphic_asexual import (
 )
 from ._alifestd_to_working_format import alifestd_to_working_format
 from ._alifestd_topological_sort import alifestd_topological_sort
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
+)
+from ._alifestd_topological_sensitivity_warned_polars import (
+    alifestd_topological_sensitivity_warned_polars,
+)
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_try_add_ancestor_id_col_polars import (
     alifestd_try_add_ancestor_id_col_polars,
@@ -543,6 +549,8 @@ __all__ = [
     "alifestd_test_leaves_isomorphic_asexual",
     "alifestd_to_working_format",
     "alifestd_topological_sort",
+    "alifestd_topological_sensitivity_warned",
+    "alifestd_topological_sensitivity_warned_polars",
     "alifestd_try_add_ancestor_id_col",
     "alifestd_try_add_ancestor_id_col_polars",
     "alifestd_try_add_ancestor_list_col",

--- a/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_global_root.py
@@ -1,4 +1,5 @@
 import argparse
+import functools
 import logging
 import os
 import types
@@ -166,8 +167,6 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
-    import functools
-
     configure_prod_logging()
 
     parser = _create_parser()

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_knuckles_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_knuckles_asexual.py
@@ -2,12 +2,15 @@ import pandas as pd
 
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_mark_leaves import alifestd_mark_leaves
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=True, delete=False, update=True,
+)
 def alifestd_add_inner_knuckles_asexual(
     phylogeny_df: pd.DataFrame, mutate: bool = False
 ) -> pd.DataFrame:
@@ -17,14 +20,6 @@ def alifestd_add_inner_knuckles_asexual(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_add_inner_knuckles_asexual",
-        insert=True,
-        delete=False,
-        update=True,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_knuckles_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_knuckles_asexual.py
@@ -3,6 +3,9 @@ import pandas as pd
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_mark_leaves import alifestd_mark_leaves
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 
 
 def alifestd_add_inner_knuckles_asexual(
@@ -14,6 +17,14 @@ def alifestd_add_inner_knuckles_asexual(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_add_inner_knuckles_asexual",
+        insert=True,
+        delete=False,
+        update=True,
+    )
+
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_knuckles_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_knuckles_asexual.py
@@ -9,7 +9,9 @@ from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=True, delete=False, update=True,
+    insert=True,
+    delete=False,
+    update=True,
 )
 def alifestd_add_inner_knuckles_asexual(
     phylogeny_df: pd.DataFrame, mutate: bool = False

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
@@ -9,8 +9,8 @@ import pandas as pd
 
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_mark_leaves import alifestd_mark_leaves
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
@@ -19,6 +19,9 @@ from ._get_hstrat_version import get_hstrat_version
 from ._log_context_duration import log_context_duration
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=True, delete=False, update=False,
+)
 def alifestd_add_inner_leaves(
     phylogeny_df: pd.DataFrame, mutate: bool = False
 ) -> pd.DataFrame:
@@ -28,14 +31,6 @@ def alifestd_add_inner_leaves(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_add_inner_leaves",
-        insert=True,
-        delete=False,
-        update=False,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
@@ -12,6 +12,7 @@ from ._alifestd_mark_leaves import alifestd_mark_leaves
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -92,6 +93,18 @@ def _create_parser() -> argparse.ArgumentParser:
         dfcli_module="hstrat._auxiliary_lib._alifestd_add_inner_leaves",
         dfcli_version=get_hstrat_version(),
     )
+    add_bool_arg(
+        parser,
+        "ignore-topological-sensitivity",
+        default=False,
+        help="suppress topological sensitivity warning (default: False)",
+    )
+    add_bool_arg(
+        parser,
+        "drop-topological-sensitivity",
+        default=False,
+        help="drop topology-sensitive columns from output (default: False)",
+    )
     return parser
 
 
@@ -106,6 +119,10 @@ if __name__ == "__main__":
         _run_dataframe_cli(
             base_parser=parser,
             output_dataframe_op=delegate_polars_implementation()(
-                alifestd_add_inner_leaves,
+                lambda df: alifestd_add_inner_leaves(
+                    df,
+                    ignore_topological_sensitivity=args.ignore_topological_sensitivity,
+                    drop_topological_sensitivity=args.drop_topological_sensitivity,
+                ),
             ),
         )

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
@@ -7,12 +7,12 @@ from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import numpy as np
 import pandas as pd
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_mark_leaves import alifestd_mark_leaves
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
-from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -21,7 +21,9 @@ from ._log_context_duration import log_context_duration
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=True, delete=False, update=False,
+    insert=True,
+    delete=False,
+    update=False,
 )
 def alifestd_add_inner_leaves(
     phylogeny_df: pd.DataFrame, mutate: bool = False

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
@@ -1,4 +1,5 @@
 import argparse
+import functools
 import logging
 import os
 
@@ -111,8 +112,6 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
-    import functools
-
     configure_prod_logging()
 
     parser = _create_parser()

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
@@ -111,6 +111,8 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
+    import functools
+
     configure_prod_logging()
 
     parser = _create_parser()
@@ -121,8 +123,8 @@ if __name__ == "__main__":
         _run_dataframe_cli(
             base_parser=parser,
             output_dataframe_op=delegate_polars_implementation()(
-                lambda df: alifestd_add_inner_leaves(
-                    df,
+                functools.partial(
+                    alifestd_add_inner_leaves,
                     ignore_topological_sensitivity=args.ignore_topological_sensitivity,
                     drop_topological_sensitivity=args.drop_topological_sensitivity,
                 ),

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_leaves.py
@@ -9,6 +9,9 @@ import pandas as pd
 
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_mark_leaves import alifestd_mark_leaves
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -25,6 +28,14 @@ def alifestd_add_inner_leaves(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_add_inner_leaves",
+        insert=True,
+        delete=False,
+        update=False,
+    )
+
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_niblings_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_niblings_asexual.py
@@ -11,7 +11,9 @@ from ._alifestd_topological_sensitivity_warned import (
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=True, delete=False, update=True,
+    insert=True,
+    delete=False,
+    update=True,
 )
 def alifestd_add_inner_niblings_asexual(
     phylogeny_df: pd.DataFrame, mutate: bool = False

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_niblings_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_niblings_asexual.py
@@ -5,11 +5,14 @@ from ._alifestd_add_inner_knuckles_asexual import (
 )
 from ._alifestd_mark_leaves import alifestd_mark_leaves
 from ._alifestd_mark_node_depth_asexual import alifestd_mark_node_depth_asexual
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=True, delete=False, update=True,
+)
 def alifestd_add_inner_niblings_asexual(
     phylogeny_df: pd.DataFrame, mutate: bool = False
 ) -> pd.DataFrame:
@@ -23,14 +26,6 @@ def alifestd_add_inner_niblings_asexual(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_add_inner_niblings_asexual",
-        insert=True,
-        delete=False,
-        update=True,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_add_inner_niblings_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_add_inner_niblings_asexual.py
@@ -5,6 +5,9 @@ from ._alifestd_add_inner_knuckles_asexual import (
 )
 from ._alifestd_mark_leaves import alifestd_mark_leaves
 from ._alifestd_mark_node_depth_asexual import alifestd_mark_node_depth_asexual
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 
 
 def alifestd_add_inner_niblings_asexual(
@@ -20,6 +23,14 @@ def alifestd_add_inner_niblings_asexual(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_add_inner_niblings_asexual",
+        insert=True,
+        delete=False,
+        update=True,
+    )
+
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
+++ b/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
@@ -8,10 +8,10 @@ from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_parse_ancestor_ids import alifestd_parse_ancestor_ids
 from ._alifestd_topological_sort import alifestd_topological_sort
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 
 
 def _alifestd_coarsen_mask_asexual(
@@ -105,6 +105,9 @@ def _alifestd_coarsen_mask_sexual(
     return res
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=True, update=True,
+)
 def alifestd_coarsen_mask(
     phylogeny_df: pd.DataFrame,
     mask: pd.Series,  # boolean mask
@@ -119,15 +122,6 @@ def alifestd_coarsen_mask(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
-
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_coarsen_mask",
-        insert=False,
-        delete=True,
-        update=True,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
+++ b/hstrat/_auxiliary_lib/_alifestd_coarsen_mask.py
@@ -7,10 +7,10 @@ from ._alifestd_is_asexual import alifestd_is_asexual
 from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_parse_ancestor_ids import alifestd_parse_ancestor_ids
-from ._alifestd_topological_sort import alifestd_topological_sort
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._alifestd_topological_sort import alifestd_topological_sort
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 
 
@@ -106,7 +106,9 @@ def _alifestd_coarsen_mask_sexual(
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=True, update=True,
+    insert=False,
+    delete=True,
+    update=True,
 )
 def alifestd_coarsen_mask(
     phylogeny_df: pd.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_coarsen_taxa_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_coarsen_taxa_asexual.py
@@ -140,14 +140,13 @@ def alifestd_coarsen_taxa_asexual(
     else:
         phylogeny_df.set_index("id", drop=False, inplace=True)
 
-    phylogeny_df["alifestd_coarsen_taxa_asexual_is_taxon_founder"] = (
-        np.logical_or.reduce(
-            phylogeny_df.loc[:, by].values.T
-            != phylogeny_df.loc[
-                phylogeny_df["ancestor_id"].values, by
-            ].values.T
-        )
-        | (phylogeny_df["is_root"].values)
+    phylogeny_df[
+        "alifestd_coarsen_taxa_asexual_is_taxon_founder"
+    ] = np.logical_or.reduce(
+        phylogeny_df.loc[:, by].values.T
+        != phylogeny_df.loc[phylogeny_df["ancestor_id"].values, by].values.T
+    ) | (
+        phylogeny_df["is_root"].values
     )
 
     if alifestd_has_contiguous_ids(phylogeny_df):
@@ -213,9 +212,9 @@ def _alifestd_coarsen_taxa_asexual_slow_path(
     `alifestd_mark_num_preceding_leaves_asexual`."""
     phylogeny_df.set_index("id", drop=False, inplace=True)
 
-    phylogeny_df["alifestd_coarsen_taxa_asexual_taxon_founder_id"] = (
-        phylogeny_df["id"]
-    )
+    phylogeny_df[
+        "alifestd_coarsen_taxa_asexual_taxon_founder_id"
+    ] = phylogeny_df["id"]
 
     for idx in phylogeny_df.index:
         ancestor_id = phylogeny_df.at[idx, "ancestor_id"]

--- a/hstrat/_auxiliary_lib/_alifestd_coarsen_taxa_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_coarsen_taxa_asexual.py
@@ -9,8 +9,8 @@ from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_mark_roots import alifestd_mark_roots
 from ._alifestd_topological_sort import alifestd_topological_sort
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 from ._jit import jit
 
@@ -71,6 +71,9 @@ def alifestd_coarsen_taxa_asexual_make_agg(
     }
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=True, update=True,
+)
 def alifestd_coarsen_taxa_asexual(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
@@ -98,14 +101,6 @@ def alifestd_coarsen_taxa_asexual(
         Helper function to generate default `agg` dict, which may be customized
         before being passed to `alifestd_coarsen_taxa_asexual`.
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_coarsen_taxa_asexual",
-        insert=False,
-        delete=True,
-        update=True,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_coarsen_taxa_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_coarsen_taxa_asexual.py
@@ -7,11 +7,11 @@ from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_mark_roots import alifestd_mark_roots
-from ._alifestd_topological_sort import alifestd_topological_sort
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._alifestd_topological_sort import alifestd_topological_sort
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._jit import jit
 
 
@@ -72,7 +72,9 @@ def alifestd_coarsen_taxa_asexual_make_agg(
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=True, update=True,
+    insert=False,
+    delete=True,
+    update=True,
 )
 def alifestd_coarsen_taxa_asexual(
     phylogeny_df: pd.DataFrame,
@@ -138,13 +140,14 @@ def alifestd_coarsen_taxa_asexual(
     else:
         phylogeny_df.set_index("id", drop=False, inplace=True)
 
-    phylogeny_df[
-        "alifestd_coarsen_taxa_asexual_is_taxon_founder"
-    ] = np.logical_or.reduce(
-        phylogeny_df.loc[:, by].values.T
-        != phylogeny_df.loc[phylogeny_df["ancestor_id"].values, by].values.T
-    ) | (
-        phylogeny_df["is_root"].values
+    phylogeny_df["alifestd_coarsen_taxa_asexual_is_taxon_founder"] = (
+        np.logical_or.reduce(
+            phylogeny_df.loc[:, by].values.T
+            != phylogeny_df.loc[
+                phylogeny_df["ancestor_id"].values, by
+            ].values.T
+        )
+        | (phylogeny_df["is_root"].values)
     )
 
     if alifestd_has_contiguous_ids(phylogeny_df):
@@ -210,9 +213,9 @@ def _alifestd_coarsen_taxa_asexual_slow_path(
     `alifestd_mark_num_preceding_leaves_asexual`."""
     phylogeny_df.set_index("id", drop=False, inplace=True)
 
-    phylogeny_df[
-        "alifestd_coarsen_taxa_asexual_taxon_founder_id"
-    ] = phylogeny_df["id"]
+    phylogeny_df["alifestd_coarsen_taxa_asexual_taxon_founder_id"] = (
+        phylogeny_df["id"]
+    )
 
     for idx in phylogeny_df.index:
         ancestor_id = phylogeny_df.at[idx, "ancestor_id"]

--- a/hstrat/_auxiliary_lib/_alifestd_coarsen_taxa_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_coarsen_taxa_asexual.py
@@ -9,6 +9,9 @@ from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_mark_roots import alifestd_mark_roots
 from ._alifestd_topological_sort import alifestd_topological_sort
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._jit import jit
 
 
@@ -95,6 +98,14 @@ def alifestd_coarsen_taxa_asexual(
         Helper function to generate default `agg` dict, which may be customized
         before being passed to `alifestd_coarsen_taxa_asexual`.
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_coarsen_taxa_asexual",
+        insert=False,
+        delete=True,
+        update=True,
+    )
+
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_trunk_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_trunk_asexual.py
@@ -4,6 +4,9 @@ import pandas as pd
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_mark_oldest_root import alifestd_mark_oldest_root
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 
 
 def alifestd_collapse_trunk_asexual(
@@ -24,6 +27,14 @@ def alifestd_collapse_trunk_asexual(
     --------
     alifestd_delete_trunk_asexual
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_collapse_trunk_asexual",
+        insert=False,
+        delete=True,
+        update=True,
+    )
+
     if "is_trunk" not in phylogeny_df:
         raise ValueError(
             "`is_trunk` column not provided, trunk is unspecified"

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_trunk_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_trunk_asexual.py
@@ -3,14 +3,16 @@ import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_mark_oldest_root import alifestd_mark_oldest_root
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=True, update=True,
+    insert=False,
+    delete=True,
+    update=True,
 )
 def alifestd_collapse_trunk_asexual(
     phylogeny_df: pd.DataFrame,
@@ -61,9 +63,9 @@ def alifestd_collapse_trunk_asexual(
     del trunk_df
 
     if "ancestor_id" in phylogeny_df:
-        phylogeny_df.loc[
-            phylogeny_df["ancestor_is_trunk"], "ancestor_id"
-        ] = collapsed_root_id
+        phylogeny_df.loc[phylogeny_df["ancestor_is_trunk"], "ancestor_id"] = (
+            collapsed_root_id
+        )
 
     if "ancestor_list" in phylogeny_df:
         phylogeny_df.loc[

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_trunk_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_trunk_asexual.py
@@ -63,9 +63,9 @@ def alifestd_collapse_trunk_asexual(
     del trunk_df
 
     if "ancestor_id" in phylogeny_df:
-        phylogeny_df.loc[phylogeny_df["ancestor_is_trunk"], "ancestor_id"] = (
-            collapsed_root_id
-        )
+        phylogeny_df.loc[
+            phylogeny_df["ancestor_is_trunk"], "ancestor_id"
+        ] = collapsed_root_id
 
     if "ancestor_list" in phylogeny_df:
         phylogeny_df.loc[

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_trunk_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_trunk_asexual.py
@@ -4,11 +4,14 @@ import pandas as pd
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_mark_oldest_root import alifestd_mark_oldest_root
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=True, update=True,
+)
 def alifestd_collapse_trunk_asexual(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
@@ -27,14 +30,6 @@ def alifestd_collapse_trunk_asexual(
     --------
     alifestd_delete_trunk_asexual
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_collapse_trunk_asexual",
-        insert=False,
-        delete=True,
-        update=True,
-    )
-
     if "is_trunk" not in phylogeny_df:
         raise ValueError(
             "`is_trunk` column not provided, trunk is unspecified"

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
@@ -20,6 +20,7 @@ from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -201,6 +202,18 @@ def _create_parser() -> argparse.ArgumentParser:
         dfcli_module="hstrat._auxiliary_lib._alifestd_collapse_unifurcations",
         dfcli_version=get_hstrat_version(),
     )
+    add_bool_arg(
+        parser,
+        "ignore-topological-sensitivity",
+        default=False,
+        help="suppress topological sensitivity warning (default: False)",
+    )
+    add_bool_arg(
+        parser,
+        "drop-topological-sensitivity",
+        default=False,
+        help="drop topology-sensitive columns from output (default: False)",
+    )
     return parser
 
 
@@ -216,6 +229,10 @@ if __name__ == "__main__":
         _run_dataframe_cli(
             base_parser=parser,
             output_dataframe_op=delegate_polars_implementation()(
-                alifestd_collapse_unifurcations,
+                lambda df: alifestd_collapse_unifurcations(
+                    df,
+                    ignore_topological_sensitivity=args.ignore_topological_sensitivity,
+                    drop_topological_sensitivity=args.drop_topological_sensitivity,
+                ),
             ),
         )

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
@@ -9,18 +9,18 @@ from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import numpy as np
 import pandas as pd
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_assign_contiguous_ids import alifestd_assign_contiguous_ids
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_asexual import alifestd_is_asexual
 from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_parse_ancestor_ids import alifestd_parse_ancestor_ids
-from ._alifestd_topological_sort import alifestd_topological_sort
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
-from ._add_bool_arg import add_bool_arg
+from ._alifestd_topological_sort import alifestd_topological_sort
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -99,7 +99,9 @@ def _alifestd_collapse_unifurcations_asexual(
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=True, update=True,
+    insert=False,
+    delete=True,
+    update=True,
 )
 def alifestd_collapse_unifurcations(
     phylogeny_df: pd.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
@@ -17,8 +17,8 @@ from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_parse_ancestor_ids import alifestd_parse_ancestor_ids
 from ._alifestd_topological_sort import alifestd_topological_sort
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
@@ -97,6 +97,9 @@ def _alifestd_collapse_unifurcations_asexual(
     return phylogeny_df
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=True, update=True,
+)
 def alifestd_collapse_unifurcations(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
@@ -121,15 +124,6 @@ def alifestd_collapse_unifurcations(
     alifestd_collapse_unifurcations_polars :
         Polars-based implementation.
     """
-
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_collapse_unifurcations",
-        insert=False,
-        delete=True,
-        update=True,
-    )
-
     # special optimized handling for asexual phylogenies
     if alifestd_is_asexual(phylogeny_df):
         return _alifestd_collapse_unifurcations_asexual(

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
@@ -1,5 +1,6 @@
 import argparse
 from collections import Counter
+import functools
 import logging
 import os
 import typing
@@ -220,8 +221,6 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
-    import functools
-
     configure_prod_logging()
 
     parser = _create_parser()

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations.py
@@ -220,6 +220,8 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
+    import functools
+
     configure_prod_logging()
 
     parser = _create_parser()
@@ -231,8 +233,8 @@ if __name__ == "__main__":
         _run_dataframe_cli(
             base_parser=parser,
             output_dataframe_op=delegate_polars_implementation()(
-                lambda df: alifestd_collapse_unifurcations(
-                    df,
+                functools.partial(
+                    alifestd_collapse_unifurcations,
                     ignore_topological_sensitivity=args.ignore_topological_sensitivity,
                     drop_topological_sensitivity=args.drop_topological_sensitivity,
                 ),

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -6,6 +6,7 @@ import joinem
 from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import polars as pl
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_assign_contiguous_ids_polars import (
     alifestd_assign_contiguous_ids_polars,
 )
@@ -19,7 +20,6 @@ from ._alifestd_is_topologically_sorted_polars import (
 from ._alifestd_topological_sensitivity_warned_polars import (
     alifestd_topological_sensitivity_warned_polars,
 )
-from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
@@ -27,7 +27,9 @@ from ._log_context_duration import log_context_duration
 
 
 @alifestd_topological_sensitivity_warned_polars(
-    insert=False, delete=True, update=True,
+    insert=False,
+    delete=True,
+    update=True,
 )
 def alifestd_collapse_unifurcations_polars(
     phylogeny_df: pl.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -1,4 +1,5 @@
 import argparse
+import functools
 import logging
 import os
 
@@ -155,8 +156,6 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
-    import functools
-
     configure_prod_logging()
 
     parser = _create_parser()

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -155,6 +155,8 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
+    import functools
+
     configure_prod_logging()
 
     parser = _create_parser()
@@ -167,8 +169,8 @@ if __name__ == "__main__":
         ):
             _run_dataframe_cli(
                 base_parser=parser,
-                output_dataframe_op=lambda df: alifestd_collapse_unifurcations_polars(
-                    df,
+                output_dataframe_op=functools.partial(
+                    alifestd_collapse_unifurcations_polars,
                     ignore_topological_sensitivity=args.ignore_topological_sensitivity,
                     drop_topological_sensitivity=args.drop_topological_sensitivity,
                 ),

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -16,8 +16,8 @@ from ._alifestd_has_contiguous_ids_polars import (
 from ._alifestd_is_topologically_sorted_polars import (
     alifestd_is_topologically_sorted_polars,
 )
-from ._alifestd_warn_topological_sensitivity_polars import (
-    alifestd_warn_topological_sensitivity_polars,
+from ._alifestd_topological_sensitivity_warned_polars import (
+    alifestd_topological_sensitivity_warned_polars,
 )
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
@@ -25,6 +25,9 @@ from ._get_hstrat_version import get_hstrat_version
 from ._log_context_duration import log_context_duration
 
 
+@alifestd_topological_sensitivity_warned_polars(
+    insert=False, delete=True, update=True,
+)
 def alifestd_collapse_unifurcations_polars(
     phylogeny_df: pl.DataFrame,
 ) -> pl.DataFrame:
@@ -40,14 +43,6 @@ def alifestd_collapse_unifurcations_polars(
         Pandas-based implementation.
     """
     schema_names = phylogeny_df.lazy().collect_schema().names()
-
-    alifestd_warn_topological_sensitivity_polars(
-        phylogeny_df,
-        "alifestd_collapse_unifurcations_polars",
-        insert=False,
-        delete=True,
-        update=True,
-    )
 
     if "ancestor_list" in schema_names:
         raise NotImplementedError

--- a/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_collapse_unifurcations_polars.py
@@ -19,6 +19,7 @@ from ._alifestd_is_topologically_sorted_polars import (
 from ._alifestd_topological_sensitivity_warned_polars import (
     alifestd_topological_sensitivity_warned_polars,
 )
+from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
@@ -136,6 +137,18 @@ def _create_parser() -> argparse.ArgumentParser:
         dfcli_module="hstrat._auxiliary_lib._alifestd_collapse_unifurcations_polars",
         dfcli_version=get_hstrat_version(),
     )
+    add_bool_arg(
+        parser,
+        "ignore-topological-sensitivity",
+        default=False,
+        help="suppress topological sensitivity warning (default: False)",
+    )
+    add_bool_arg(
+        parser,
+        "drop-topological-sensitivity",
+        default=False,
+        help="drop topology-sensitive columns from output (default: False)",
+    )
     return parser
 
 
@@ -152,7 +165,11 @@ if __name__ == "__main__":
         ):
             _run_dataframe_cli(
                 base_parser=parser,
-                output_dataframe_op=alifestd_collapse_unifurcations_polars,
+                output_dataframe_op=lambda df: alifestd_collapse_unifurcations_polars(
+                    df,
+                    ignore_topological_sensitivity=args.ignore_topological_sensitivity,
+                    drop_topological_sensitivity=args.drop_topological_sensitivity,
+                ),
             )
     except NotImplementedError as e:
         logging.error(

--- a/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual.py
@@ -74,11 +74,11 @@ def alifestd_delete_trunk_asexual(
         logging.info(
             "- alifestd_delete_trunk_asexual: updating ancestor_id...",
         )
-        phylogeny_df.loc[phylogeny_df["ancestor_is_trunk"], "ancestor_id"] = (
-            phylogeny_df.loc[
-                phylogeny_df["ancestor_is_trunk"], "id"
-            ].to_numpy()
-        )
+        phylogeny_df.loc[
+            phylogeny_df["ancestor_is_trunk"], "ancestor_id"
+        ] = phylogeny_df.loc[
+            phylogeny_df["ancestor_is_trunk"], "id"
+        ].to_numpy()
 
     if "ancestor_list" in phylogeny_df:
         logging.info(

--- a/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual.py
@@ -6,11 +6,14 @@ import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=True, update=True,
+)
 def alifestd_delete_trunk_asexual(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
@@ -29,14 +32,6 @@ def alifestd_delete_trunk_asexual(
     --------
     alifestd_collapse_trunk_asexual
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_delete_trunk_asexual",
-        insert=False,
-        delete=True,
-        update=True,
-    )
-
     if "is_trunk" not in phylogeny_df:
         raise ValueError(
             "`is_trunk` column not provided, trunk is unspecified"

--- a/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual.py
@@ -5,14 +5,16 @@ import numpy as np
 import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=True, update=True,
+    insert=False,
+    delete=True,
+    update=True,
 )
 def alifestd_delete_trunk_asexual(
     phylogeny_df: pd.DataFrame,
@@ -72,11 +74,11 @@ def alifestd_delete_trunk_asexual(
         logging.info(
             "- alifestd_delete_trunk_asexual: updating ancestor_id...",
         )
-        phylogeny_df.loc[
-            phylogeny_df["ancestor_is_trunk"], "ancestor_id"
-        ] = phylogeny_df.loc[
-            phylogeny_df["ancestor_is_trunk"], "id"
-        ].to_numpy()
+        phylogeny_df.loc[phylogeny_df["ancestor_is_trunk"], "ancestor_id"] = (
+            phylogeny_df.loc[
+                phylogeny_df["ancestor_is_trunk"], "id"
+            ].to_numpy()
+        )
 
     if "ancestor_list" in phylogeny_df:
         logging.info(

--- a/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual.py
@@ -6,6 +6,9 @@ import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 
 
 def alifestd_delete_trunk_asexual(
@@ -26,6 +29,14 @@ def alifestd_delete_trunk_asexual(
     --------
     alifestd_collapse_trunk_asexual
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_delete_trunk_asexual",
+        insert=False,
+        delete=True,
+        update=True,
+    )
+
     if "is_trunk" not in phylogeny_df:
         raise ValueError(
             "`is_trunk` column not provided, trunk is unspecified"

--- a/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual_polars.py
@@ -2,14 +2,16 @@ import logging
 
 import polars as pl
 
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned_polars import (
     alifestd_topological_sensitivity_warned_polars,
 )
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 
 
 @alifestd_topological_sensitivity_warned_polars(
-    insert=False, delete=True, update=True,
+    insert=False,
+    delete=True,
+    update=True,
 )
 def alifestd_delete_trunk_asexual_polars(
     phylogeny_df: pl.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual_polars.py
@@ -3,11 +3,14 @@ import logging
 import polars as pl
 
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity_polars import (
-    alifestd_warn_topological_sensitivity_polars,
+from ._alifestd_topological_sensitivity_warned_polars import (
+    alifestd_topological_sensitivity_warned_polars,
 )
 
 
+@alifestd_topological_sensitivity_warned_polars(
+    insert=False, delete=True, update=True,
+)
 def alifestd_delete_trunk_asexual_polars(
     phylogeny_df: pl.DataFrame,
 ) -> pl.DataFrame:
@@ -25,14 +28,6 @@ def alifestd_delete_trunk_asexual_polars(
     --------
     alifestd_collapse_trunk_asexual
     """
-    alifestd_warn_topological_sensitivity_polars(
-        phylogeny_df,
-        "alifestd_delete_trunk_asexual_polars",
-        insert=False,
-        delete=True,
-        update=True,
-    )
-
     phylogeny_df = phylogeny_df.lazy().collect()  # lazy not yet implemented
 
     if "is_trunk" not in phylogeny_df:

--- a/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_trunk_asexual_polars.py
@@ -3,6 +3,9 @@ import logging
 import polars as pl
 
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_warn_topological_sensitivity_polars import (
+    alifestd_warn_topological_sensitivity_polars,
+)
 
 
 def alifestd_delete_trunk_asexual_polars(
@@ -22,6 +25,14 @@ def alifestd_delete_trunk_asexual_polars(
     --------
     alifestd_collapse_trunk_asexual
     """
+    alifestd_warn_topological_sensitivity_polars(
+        phylogeny_df,
+        "alifestd_delete_trunk_asexual_polars",
+        insert=False,
+        delete=True,
+        update=True,
+    )
+
     phylogeny_df = phylogeny_df.lazy().collect()  # lazy not yet implemented
 
     if "is_trunk" not in phylogeny_df:

--- a/hstrat/_auxiliary_lib/_alifestd_delete_unifurcating_roots_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_unifurcating_roots_asexual.py
@@ -7,14 +7,16 @@ from ._alifestd_mark_num_children_asexual import (
     alifestd_mark_num_children_asexual,
 )
 from ._alifestd_mark_roots import alifestd_mark_roots
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=True, update=True,
+    insert=False,
+    delete=True,
+    update=True,
 )
 def alifestd_delete_unifurcating_roots_asexual(
     phylogeny_df: pd.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_delete_unifurcating_roots_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_unifurcating_roots_asexual.py
@@ -8,6 +8,9 @@ from ._alifestd_mark_num_children_asexual import (
 )
 from ._alifestd_mark_roots import alifestd_mark_roots
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 
 
 def alifestd_delete_unifurcating_roots_asexual(
@@ -30,6 +33,13 @@ def alifestd_delete_unifurcating_roots_asexual(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_delete_unifurcating_roots_asexual",
+        insert=False,
+        delete=True,
+        update=True,
+    )
 
     if not mutate:
         phylogeny_df = phylogeny_df.copy()

--- a/hstrat/_auxiliary_lib/_alifestd_delete_unifurcating_roots_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_delete_unifurcating_roots_asexual.py
@@ -8,11 +8,14 @@ from ._alifestd_mark_num_children_asexual import (
 )
 from ._alifestd_mark_roots import alifestd_mark_roots
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=True, update=True,
+)
 def alifestd_delete_unifurcating_roots_asexual(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
@@ -33,14 +36,6 @@ def alifestd_delete_unifurcating_roots_asexual(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_delete_unifurcating_roots_asexual",
-        insert=False,
-        delete=True,
-        update=True,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_asexual.py
@@ -10,16 +10,16 @@ from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import numpy as np
 import pandas as pd
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_find_leaf_ids import alifestd_find_leaf_ids
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_prune_extinct_lineages_asexual import (
     alifestd_prune_extinct_lineages_asexual,
 )
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
-from ._add_bool_arg import add_bool_arg
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -48,7 +48,9 @@ def _alifestd_downsample_tips_asexual_impl(
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=True, update=False,
+    insert=False,
+    delete=True,
+    update=False,
 )
 def alifestd_downsample_tips_asexual(
     phylogeny_df: pd.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_asexual.py
@@ -16,6 +16,9 @@ from ._alifestd_prune_extinct_lineages_asexual import (
     alifestd_prune_extinct_lineages_asexual,
 )
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -55,6 +58,14 @@ def alifestd_downsample_tips_asexual(
 
     Only supports asexual phylogenies.
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_downsample_tips_asexual",
+        insert=False,
+        delete=True,
+        update=False,
+    )
+
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_asexual.py
@@ -16,8 +16,8 @@ from ._alifestd_prune_extinct_lineages_asexual import (
     alifestd_prune_extinct_lineages_asexual,
 )
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
@@ -46,6 +46,9 @@ def _alifestd_downsample_tips_asexual_impl(
     ).drop(columns=["extant"])
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=True, update=False,
+)
 def alifestd_downsample_tips_asexual(
     phylogeny_df: pd.DataFrame,
     n_downsample: int,
@@ -58,14 +61,6 @@ def alifestd_downsample_tips_asexual(
 
     Only supports asexual phylogenies.
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_downsample_tips_asexual",
-        insert=False,
-        delete=True,
-        update=False,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_asexual.py
@@ -19,6 +19,7 @@ from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -132,6 +133,18 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Integer seed for deterministic behavior.",
         type=int,
     )
+    add_bool_arg(
+        parser,
+        "ignore-topological-sensitivity",
+        default=False,
+        help="suppress topological sensitivity warning (default: False)",
+    )
+    add_bool_arg(
+        parser,
+        "drop-topological-sensitivity",
+        default=False,
+        help="drop topology-sensitive columns from output (default: False)",
+    )
     return parser
 
 
@@ -150,6 +163,8 @@ if __name__ == "__main__":
                     alifestd_downsample_tips_asexual,
                     n_downsample=args.n,
                     seed=args.seed,
+                    ignore_topological_sensitivity=args.ignore_topological_sensitivity,
+                    drop_topological_sensitivity=args.drop_topological_sensitivity,
                 ),
             ),
             overridden_arguments="ignore",  # seed is overridden

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_clade_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_clade_asexual.py
@@ -10,6 +10,7 @@ from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import numpy as np
 import pandas as pd
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_mark_leaves import alifestd_mark_leaves
 from ._alifestd_mark_num_leaves_asexual import alifestd_mark_num_leaves_asexual
@@ -19,11 +20,10 @@ from ._alifestd_mask_descendants_asexual import (
 from ._alifestd_prune_extinct_lineages_asexual import (
     alifestd_prune_extinct_lineages_asexual,
 )
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
-from ._add_bool_arg import add_bool_arg
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -82,7 +82,9 @@ def _alifestd_downsample_tips_clade_asexual_impl(
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=True, update=False,
+    insert=False,
+    delete=True,
+    update=False,
 )
 def alifestd_downsample_tips_clade_asexual(
     phylogeny_df: pd.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_clade_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_clade_asexual.py
@@ -20,6 +20,9 @@ from ._alifestd_prune_extinct_lineages_asexual import (
     alifestd_prune_extinct_lineages_asexual,
 )
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -92,6 +95,14 @@ def alifestd_downsample_tips_clade_asexual(
 
     Only supports asexual phylogenies.
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_downsample_tips_clade_asexual",
+        insert=False,
+        delete=True,
+        update=False,
+    )
+
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_clade_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_clade_asexual.py
@@ -20,8 +20,8 @@ from ._alifestd_prune_extinct_lineages_asexual import (
     alifestd_prune_extinct_lineages_asexual,
 )
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
@@ -80,6 +80,9 @@ def _alifestd_downsample_tips_clade_asexual_impl(
     ).drop(columns=["extant", "alifestd_mask_descendants_asexual"])
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=True, update=False,
+)
 def alifestd_downsample_tips_clade_asexual(
     phylogeny_df: pd.DataFrame,
     n_downsample: int,
@@ -95,14 +98,6 @@ def alifestd_downsample_tips_clade_asexual(
 
     Only supports asexual phylogenies.
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_downsample_tips_clade_asexual",
-        insert=False,
-        delete=True,
-        update=False,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_clade_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_clade_asexual.py
@@ -23,6 +23,7 @@ from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -167,6 +168,18 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Integer seed for deterministic behavior.",
         type=int,
     )
+    add_bool_arg(
+        parser,
+        "ignore-topological-sensitivity",
+        default=False,
+        help="suppress topological sensitivity warning (default: False)",
+    )
+    add_bool_arg(
+        parser,
+        "drop-topological-sensitivity",
+        default=False,
+        help="drop topology-sensitive columns from output (default: False)",
+    )
     return parser
 
 
@@ -186,6 +199,8 @@ if __name__ == "__main__":
                     alifestd_downsample_tips_clade_asexual,
                     n_downsample=args.n,
                     seed=args.seed,
+                    ignore_topological_sensitivity=args.ignore_topological_sensitivity,
+                    drop_topological_sensitivity=args.drop_topological_sensitivity,
                 ),
             ),
             overridden_arguments="ignore",  # seed is overridden

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_polars.py
@@ -9,6 +9,7 @@ import joinem
 from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import polars as pl
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_mark_leaves_polars import alifestd_mark_leaves_polars
 from ._alifestd_prune_extinct_lineages_polars import (
     alifestd_prune_extinct_lineages_polars,
@@ -16,7 +17,6 @@ from ._alifestd_prune_extinct_lineages_polars import (
 from ._alifestd_topological_sensitivity_warned_polars import (
     alifestd_topological_sensitivity_warned_polars,
 )
-from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
@@ -66,7 +66,9 @@ def _alifestd_downsample_tips_polars_impl(
 
 
 @alifestd_topological_sensitivity_warned_polars(
-    insert=False, delete=True, update=False,
+    insert=False,
+    delete=True,
+    update=False,
 )
 def alifestd_downsample_tips_polars(
     phylogeny_df: pl.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_polars.py
@@ -16,6 +16,7 @@ from ._alifestd_prune_extinct_lineages_polars import (
 from ._alifestd_topological_sensitivity_warned_polars import (
     alifestd_topological_sensitivity_warned_polars,
 )
+from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
@@ -167,6 +168,18 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Integer seed for deterministic behavior.",
         type=int,
     )
+    add_bool_arg(
+        parser,
+        "ignore-topological-sensitivity",
+        default=False,
+        help="suppress topological sensitivity warning (default: False)",
+    )
+    add_bool_arg(
+        parser,
+        "drop-topological-sensitivity",
+        default=False,
+        help="drop topology-sensitive columns from output (default: False)",
+    )
     return parser
 
 
@@ -187,6 +200,8 @@ if __name__ == "__main__":
                     alifestd_downsample_tips_polars,
                     n_downsample=args.n,
                     seed=args.seed,
+                    ignore_topological_sensitivity=args.ignore_topological_sensitivity,
+                    drop_topological_sensitivity=args.drop_topological_sensitivity,
                 ),
                 overridden_arguments="ignore",  # seed is overridden
             )

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_polars.py
@@ -13,6 +13,9 @@ from ._alifestd_mark_leaves_polars import alifestd_mark_leaves_polars
 from ._alifestd_prune_extinct_lineages_polars import (
     alifestd_prune_extinct_lineages_polars,
 )
+from ._alifestd_warn_topological_sensitivity_polars import (
+    alifestd_warn_topological_sensitivity_polars,
+)
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
@@ -99,6 +102,14 @@ def alifestd_downsample_tips_polars(
     alifestd_downsample_tips_asexual :
         Pandas-based implementation.
     """
+    alifestd_warn_topological_sensitivity_polars(
+        phylogeny_df,
+        "alifestd_downsample_tips_polars",
+        insert=False,
+        delete=True,
+        update=False,
+    )
+
     if "ancestor_id" not in phylogeny_df.lazy().collect_schema().names():
         raise NotImplementedError("ancestor_id column required")
 

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_polars.py
@@ -13,8 +13,8 @@ from ._alifestd_mark_leaves_polars import alifestd_mark_leaves_polars
 from ._alifestd_prune_extinct_lineages_polars import (
     alifestd_prune_extinct_lineages_polars,
 )
-from ._alifestd_warn_topological_sensitivity_polars import (
-    alifestd_warn_topological_sensitivity_polars,
+from ._alifestd_topological_sensitivity_warned_polars import (
+    alifestd_topological_sensitivity_warned_polars,
 )
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
@@ -64,6 +64,9 @@ def _alifestd_downsample_tips_polars_impl(
     return alifestd_prune_extinct_lineages_polars(phylogeny_df).drop("extant")
 
 
+@alifestd_topological_sensitivity_warned_polars(
+    insert=False, delete=True, update=False,
+)
 def alifestd_downsample_tips_polars(
     phylogeny_df: pl.DataFrame,
     n_downsample: int,
@@ -102,14 +105,6 @@ def alifestd_downsample_tips_polars(
     alifestd_downsample_tips_asexual :
         Pandas-based implementation.
     """
-    alifestd_warn_topological_sensitivity_polars(
-        phylogeny_df,
-        "alifestd_downsample_tips_polars",
-        insert=False,
-        delete=True,
-        update=False,
-    )
-
     if "ancestor_id" not in phylogeny_df.lazy().collect_schema().names():
         raise NotImplementedError("ancestor_id column required")
 

--- a/hstrat/_auxiliary_lib/_alifestd_join_roots.py
+++ b/hstrat/_auxiliary_lib/_alifestd_join_roots.py
@@ -8,6 +8,9 @@ import pandas as pd
 
 from ._alifestd_mark_oldest_root import alifestd_mark_oldest_root
 from ._alifestd_mark_roots import alifestd_mark_roots
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -25,6 +28,14 @@ def alifestd_join_roots(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_join_roots",
+        insert=False,
+        delete=False,
+        update=True,
+    )
+
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_join_roots.py
+++ b/hstrat/_auxiliary_lib/_alifestd_join_roots.py
@@ -6,12 +6,12 @@ import joinem
 from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import pandas as pd
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_mark_oldest_root import alifestd_mark_oldest_root
 from ._alifestd_mark_roots import alifestd_mark_roots
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
-from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -20,7 +20,9 @@ from ._log_context_duration import log_context_duration
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=False, update=True,
+    insert=False,
+    delete=False,
+    update=True,
 )
 def alifestd_join_roots(
     phylogeny_df: pd.DataFrame, mutate: bool = False
@@ -46,17 +48,17 @@ def alifestd_join_roots(
     ]
 
     if "ancestor_id" in phylogeny_df:
-        phylogeny_df.loc[
-            phylogeny_df["is_root"], "ancestor_id"
-        ] = global_root_id
+        phylogeny_df.loc[phylogeny_df["is_root"], "ancestor_id"] = (
+            global_root_id
+        )
 
     if "ancestor_list" in phylogeny_df:
-        phylogeny_df.loc[
-            phylogeny_df["is_root"], "ancestor_list"
-        ] = f"[{global_root_id}]"
-        phylogeny_df.loc[
-            phylogeny_df["is_oldest_root"], "ancestor_list"
-        ] = "[none]"
+        phylogeny_df.loc[phylogeny_df["is_root"], "ancestor_list"] = (
+            f"[{global_root_id}]"
+        )
+        phylogeny_df.loc[phylogeny_df["is_oldest_root"], "ancestor_list"] = (
+            "[none]"
+        )
 
     phylogeny_df["is_root"] = False
     phylogeny_df.loc[phylogeny_df["is_oldest_root"], "is_root"] = True

--- a/hstrat/_auxiliary_lib/_alifestd_join_roots.py
+++ b/hstrat/_auxiliary_lib/_alifestd_join_roots.py
@@ -8,8 +8,8 @@ import pandas as pd
 
 from ._alifestd_mark_oldest_root import alifestd_mark_oldest_root
 from ._alifestd_mark_roots import alifestd_mark_roots
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
@@ -18,6 +18,9 @@ from ._get_hstrat_version import get_hstrat_version
 from ._log_context_duration import log_context_duration
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=False, update=True,
+)
 def alifestd_join_roots(
     phylogeny_df: pd.DataFrame, mutate: bool = False
 ) -> pd.DataFrame:
@@ -28,14 +31,6 @@ def alifestd_join_roots(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_join_roots",
-        insert=False,
-        delete=False,
-        update=True,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_join_roots.py
+++ b/hstrat/_auxiliary_lib/_alifestd_join_roots.py
@@ -11,6 +11,7 @@ from ._alifestd_mark_roots import alifestd_mark_roots
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -88,6 +89,18 @@ def _create_parser() -> argparse.ArgumentParser:
         dfcli_module="hstrat._auxiliary_lib._alifestd_join_roots",
         dfcli_version=get_hstrat_version(),
     )
+    add_bool_arg(
+        parser,
+        "ignore-topological-sensitivity",
+        default=False,
+        help="suppress topological sensitivity warning (default: False)",
+    )
+    add_bool_arg(
+        parser,
+        "drop-topological-sensitivity",
+        default=False,
+        help="drop topology-sensitive columns from output (default: False)",
+    )
     return parser
 
 
@@ -102,7 +115,11 @@ if __name__ == "__main__":
         _run_dataframe_cli(
             base_parser=parser,
             output_dataframe_op=delegate_polars_implementation()(
-                alifestd_join_roots,
+                lambda df: alifestd_join_roots(
+                    df,
+                    ignore_topological_sensitivity=args.ignore_topological_sensitivity,
+                    drop_topological_sensitivity=args.drop_topological_sensitivity,
+                ),
             ),
             overridden_arguments="ignore",  # seed is overridden
         )

--- a/hstrat/_auxiliary_lib/_alifestd_join_roots.py
+++ b/hstrat/_auxiliary_lib/_alifestd_join_roots.py
@@ -48,17 +48,17 @@ def alifestd_join_roots(
     ]
 
     if "ancestor_id" in phylogeny_df:
-        phylogeny_df.loc[phylogeny_df["is_root"], "ancestor_id"] = (
-            global_root_id
-        )
+        phylogeny_df.loc[
+            phylogeny_df["is_root"], "ancestor_id"
+        ] = global_root_id
 
     if "ancestor_list" in phylogeny_df:
-        phylogeny_df.loc[phylogeny_df["is_root"], "ancestor_list"] = (
-            f"[{global_root_id}]"
-        )
-        phylogeny_df.loc[phylogeny_df["is_oldest_root"], "ancestor_list"] = (
-            "[none]"
-        )
+        phylogeny_df.loc[
+            phylogeny_df["is_root"], "ancestor_list"
+        ] = f"[{global_root_id}]"
+        phylogeny_df.loc[
+            phylogeny_df["is_oldest_root"], "ancestor_list"
+        ] = "[none]"
 
     phylogeny_df["is_root"] = False
     phylogeny_df.loc[phylogeny_df["is_oldest_root"], "is_root"] = True
@@ -107,6 +107,8 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
+    import functools
+
     configure_prod_logging()
 
     parser = _create_parser()
@@ -117,8 +119,8 @@ if __name__ == "__main__":
         _run_dataframe_cli(
             base_parser=parser,
             output_dataframe_op=delegate_polars_implementation()(
-                lambda df: alifestd_join_roots(
-                    df,
+                functools.partial(
+                    alifestd_join_roots,
                     ignore_topological_sensitivity=args.ignore_topological_sensitivity,
                     drop_topological_sensitivity=args.drop_topological_sensitivity,
                 ),

--- a/hstrat/_auxiliary_lib/_alifestd_join_roots.py
+++ b/hstrat/_auxiliary_lib/_alifestd_join_roots.py
@@ -1,4 +1,5 @@
 import argparse
+import functools
 import logging
 import os
 
@@ -107,8 +108,6 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
-    import functools
-
     configure_prod_logging()
 
     parser = _create_parser()

--- a/hstrat/_auxiliary_lib/_alifestd_prefix_roots.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prefix_roots.py
@@ -8,8 +8,8 @@ import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_mark_roots import alifestd_mark_roots
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 
 
@@ -33,6 +33,9 @@ def _alifestd_prefix_roots_fast(
     return pd.concat([prepended_roots, phylogeny_df], ignore_index=True)
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=True, delete=False, update=True,
+)
 def alifestd_prefix_roots(
     phylogeny_df: pd.DataFrame,
     *,
@@ -50,14 +53,6 @@ def alifestd_prefix_roots(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_prefix_roots",
-        insert=True,
-        delete=False,
-        update=True,
-    )
-
     if "origin_time_delta" in phylogeny_df:
         warnings.warn("alifestd_prefix_roots ignores origin_time_delta values")
     if origin_time is not None and "origin_time" not in phylogeny_df:

--- a/hstrat/_auxiliary_lib/_alifestd_prefix_roots.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prefix_roots.py
@@ -8,6 +8,9 @@ import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_mark_roots import alifestd_mark_roots
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 
 
 def _alifestd_prefix_roots_fast(
@@ -47,6 +50,14 @@ def alifestd_prefix_roots(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_prefix_roots",
+        insert=True,
+        delete=False,
+        update=True,
+    )
+
     if "origin_time_delta" in phylogeny_df:
         warnings.warn("alifestd_prefix_roots ignores origin_time_delta values")
     if origin_time is not None and "origin_time" not in phylogeny_df:

--- a/hstrat/_auxiliary_lib/_alifestd_prefix_roots.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prefix_roots.py
@@ -34,7 +34,9 @@ def _alifestd_prefix_roots_fast(
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=True, delete=False, update=True,
+    insert=True,
+    delete=False,
+    update=True,
 )
 def alifestd_prefix_roots(
     phylogeny_df: pd.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_prefix_roots_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prefix_roots_polars.py
@@ -7,11 +7,14 @@ import numpy as np
 import opytional as opyt
 import polars as pl
 
-from ._alifestd_warn_topological_sensitivity_polars import (
-    alifestd_warn_topological_sensitivity_polars,
+from ._alifestd_topological_sensitivity_warned_polars import (
+    alifestd_topological_sensitivity_warned_polars,
 )
 
 
+@alifestd_topological_sensitivity_warned_polars(
+    insert=True, delete=False, update=True,
+)
 def alifestd_prefix_roots_polars(
     phylogeny_df: pl.DataFrame,
     *,
@@ -28,14 +31,6 @@ def alifestd_prefix_roots_polars(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
-    alifestd_warn_topological_sensitivity_polars(
-        phylogeny_df,
-        "alifestd_prefix_roots_polars",
-        insert=True,
-        delete=False,
-        update=True,
-    )
-
     if "origin_time_delta" in phylogeny_df:
         warnings.warn("alifestd_prefix_roots ignores origin_time_delta values")
     if origin_time is not None and "origin_time" not in phylogeny_df:

--- a/hstrat/_auxiliary_lib/_alifestd_prefix_roots_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prefix_roots_polars.py
@@ -13,7 +13,9 @@ from ._alifestd_topological_sensitivity_warned_polars import (
 
 
 @alifestd_topological_sensitivity_warned_polars(
-    insert=True, delete=False, update=True,
+    insert=True,
+    delete=False,
+    update=True,
 )
 def alifestd_prefix_roots_polars(
     phylogeny_df: pl.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_prefix_roots_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prefix_roots_polars.py
@@ -7,6 +7,10 @@ import numpy as np
 import opytional as opyt
 import polars as pl
 
+from ._alifestd_warn_topological_sensitivity_polars import (
+    alifestd_warn_topological_sensitivity_polars,
+)
+
 
 def alifestd_prefix_roots_polars(
     phylogeny_df: pl.DataFrame,
@@ -24,6 +28,14 @@ def alifestd_prefix_roots_polars(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
+    alifestd_warn_topological_sensitivity_polars(
+        phylogeny_df,
+        "alifestd_prefix_roots_polars",
+        insert=True,
+        delete=False,
+        update=True,
+    )
+
     if "origin_time_delta" in phylogeny_df:
         warnings.warn("alifestd_prefix_roots ignores origin_time_delta values")
     if origin_time is not None and "origin_time" not in phylogeny_df:

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
@@ -218,6 +218,8 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
+    import functools
+
     configure_prod_logging()
 
     parser = _create_parser()
@@ -229,8 +231,8 @@ if __name__ == "__main__":
         _run_dataframe_cli(
             base_parser=parser,
             output_dataframe_op=delegate_polars_implementation()(
-                lambda df: alifestd_prune_extinct_lineages_asexual(
-                    df,
+                functools.partial(
+                    alifestd_prune_extinct_lineages_asexual,
                     ignore_topological_sensitivity=args.ignore_topological_sensitivity,
                     drop_topological_sensitivity=args.drop_topological_sensitivity,
                 ),

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
@@ -12,6 +12,9 @@ from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_unfurl_lineage_asexual import alifestd_unfurl_lineage_asexual
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -112,6 +115,13 @@ def alifestd_prune_extinct_lineages_asexual(
     pandas.DataFrame
         The rerooted phylogeny in alife standard format.
     """
+    alifestd_warn_topological_sensitivity(
+        phylogeny_df,
+        "alifestd_prune_extinct_lineages_asexual",
+        insert=False,
+        delete=True,
+        update=False,
+    )
 
     if not mutate:
         phylogeny_df = phylogeny_df.copy()

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
@@ -12,8 +12,8 @@ from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_unfurl_lineage_asexual import alifestd_unfurl_lineage_asexual
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
@@ -82,6 +82,9 @@ def _create_has_extant_descendant_contiguous_sorted(
     return has_extant_descendant
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=True, update=False,
+)
 def alifestd_prune_extinct_lineages_asexual(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
@@ -115,14 +118,6 @@ def alifestd_prune_extinct_lineages_asexual(
     pandas.DataFrame
         The rerooted phylogeny in alife standard format.
     """
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_prune_extinct_lineages_asexual",
-        insert=False,
-        delete=True,
-        update=False,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
@@ -8,14 +8,14 @@ from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import numpy as np
 import pandas as pd
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_unfurl_lineage_asexual import alifestd_unfurl_lineage_asexual
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
-from ._add_bool_arg import add_bool_arg
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_unfurl_lineage_asexual import alifestd_unfurl_lineage_asexual
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -84,7 +84,9 @@ def _create_has_extant_descendant_contiguous_sorted(
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=True, update=False,
+    insert=False,
+    delete=True,
+    update=False,
 )
 def alifestd_prune_extinct_lineages_asexual(
     phylogeny_df: pd.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
@@ -15,6 +15,7 @@ from ._alifestd_unfurl_lineage_asexual import alifestd_unfurl_lineage_asexual
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
@@ -199,6 +200,18 @@ def _create_parser() -> argparse.ArgumentParser:
         dfcli_module="hstrat._auxiliary_lib._alifestd_prune_extinct_lineages_asexual",
         dfcli_version=get_hstrat_version(),
     )
+    add_bool_arg(
+        parser,
+        "ignore-topological-sensitivity",
+        default=False,
+        help="suppress topological sensitivity warning (default: False)",
+    )
+    add_bool_arg(
+        parser,
+        "drop-topological-sensitivity",
+        default=False,
+        help="drop topology-sensitive columns from output (default: False)",
+    )
     return parser
 
 
@@ -214,6 +227,10 @@ if __name__ == "__main__":
         _run_dataframe_cli(
             base_parser=parser,
             output_dataframe_op=delegate_polars_implementation()(
-                alifestd_prune_extinct_lineages_asexual,
+                lambda df: alifestd_prune_extinct_lineages_asexual(
+                    df,
+                    ignore_topological_sensitivity=args.ignore_topological_sensitivity,
+                    drop_topological_sensitivity=args.drop_topological_sensitivity,
+                ),
             ),
         )

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_asexual.py
@@ -1,4 +1,5 @@
 import argparse
+import functools
 import logging
 import operator
 import os
@@ -218,8 +219,6 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
-    import functools
-
     configure_prod_logging()
 
     parser = _create_parser()

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
@@ -15,6 +15,9 @@ from ._alifestd_is_topologically_sorted_polars import (
 from ._alifestd_prune_extinct_lineages_asexual import (
     _create_has_extant_descendant_contiguous_sorted,
 )
+from ._alifestd_warn_topological_sensitivity_polars import (
+    alifestd_warn_topological_sensitivity_polars,
+)
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
@@ -57,6 +60,14 @@ def alifestd_prune_extinct_lineages_polars(
     alifestd_prune_extinct_lineages_asexual :
         Pandas-based implementation.
     """
+    alifestd_warn_topological_sensitivity_polars(
+        phylogeny_df,
+        "alifestd_prune_extinct_lineages_polars",
+        insert=False,
+        delete=True,
+        update=False,
+    )
+
     schema_names = phylogeny_df.lazy().collect_schema().names()
     if "ancestor_id" not in schema_names:
         raise NotImplementedError("ancestor_id column required")

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
@@ -6,6 +6,7 @@ import joinem
 from joinem._dataframe_cli import _add_parser_base, _run_dataframe_cli
 import polars as pl
 
+from ._add_bool_arg import add_bool_arg
 from ._alifestd_has_contiguous_ids_polars import (
     alifestd_has_contiguous_ids_polars,
 )
@@ -18,7 +19,6 @@ from ._alifestd_prune_extinct_lineages_asexual import (
 from ._alifestd_topological_sensitivity_warned_polars import (
     alifestd_topological_sensitivity_warned_polars,
 )
-from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
@@ -26,7 +26,9 @@ from ._log_context_duration import log_context_duration
 
 
 @alifestd_topological_sensitivity_warned_polars(
-    insert=False, delete=True, update=False,
+    insert=False,
+    delete=True,
+    update=False,
 )
 def alifestd_prune_extinct_lineages_polars(
     phylogeny_df: pl.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
@@ -197,6 +197,8 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
+    import functools
+
     configure_prod_logging()
 
     parser = _create_parser()
@@ -209,8 +211,8 @@ if __name__ == "__main__":
         ):
             _run_dataframe_cli(
                 base_parser=parser,
-                output_dataframe_op=lambda df: alifestd_prune_extinct_lineages_polars(
-                    df,
+                output_dataframe_op=functools.partial(
+                    alifestd_prune_extinct_lineages_polars,
                     ignore_topological_sensitivity=args.ignore_topological_sensitivity,
                     drop_topological_sensitivity=args.drop_topological_sensitivity,
                 ),

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
@@ -1,4 +1,5 @@
 import argparse
+import functools
 import logging
 import os
 
@@ -197,8 +198,6 @@ def _create_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
-    import functools
-
     configure_prod_logging()
 
     parser = _create_parser()

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
@@ -15,8 +15,8 @@ from ._alifestd_is_topologically_sorted_polars import (
 from ._alifestd_prune_extinct_lineages_asexual import (
     _create_has_extant_descendant_contiguous_sorted,
 )
-from ._alifestd_warn_topological_sensitivity_polars import (
-    alifestd_warn_topological_sensitivity_polars,
+from ._alifestd_topological_sensitivity_warned_polars import (
+    alifestd_topological_sensitivity_warned_polars,
 )
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
@@ -24,6 +24,9 @@ from ._get_hstrat_version import get_hstrat_version
 from ._log_context_duration import log_context_duration
 
 
+@alifestd_topological_sensitivity_warned_polars(
+    insert=False, delete=True, update=False,
+)
 def alifestd_prune_extinct_lineages_polars(
     phylogeny_df: pl.DataFrame,
 ) -> pl.DataFrame:
@@ -60,14 +63,6 @@ def alifestd_prune_extinct_lineages_polars(
     alifestd_prune_extinct_lineages_asexual :
         Pandas-based implementation.
     """
-    alifestd_warn_topological_sensitivity_polars(
-        phylogeny_df,
-        "alifestd_prune_extinct_lineages_polars",
-        insert=False,
-        delete=True,
-        update=False,
-    )
-
     schema_names = phylogeny_df.lazy().collect_schema().names()
     if "ancestor_id" not in schema_names:
         raise NotImplementedError("ancestor_id column required")

--- a/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_prune_extinct_lineages_polars.py
@@ -18,6 +18,7 @@ from ._alifestd_prune_extinct_lineages_asexual import (
 from ._alifestd_topological_sensitivity_warned_polars import (
     alifestd_topological_sensitivity_warned_polars,
 )
+from ._add_bool_arg import add_bool_arg
 from ._configure_prod_logging import configure_prod_logging
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
@@ -178,6 +179,18 @@ def _create_parser() -> argparse.ArgumentParser:
         dfcli_module="hstrat._auxiliary_lib._alifestd_prune_extinct_lineages_polars",
         dfcli_version=get_hstrat_version(),
     )
+    add_bool_arg(
+        parser,
+        "ignore-topological-sensitivity",
+        default=False,
+        help="suppress topological sensitivity warning (default: False)",
+    )
+    add_bool_arg(
+        parser,
+        "drop-topological-sensitivity",
+        default=False,
+        help="drop topology-sensitive columns from output (default: False)",
+    )
     return parser
 
 
@@ -194,7 +207,11 @@ if __name__ == "__main__":
         ):
             _run_dataframe_cli(
                 base_parser=parser,
-                output_dataframe_op=alifestd_prune_extinct_lineages_polars,
+                output_dataframe_op=lambda df: alifestd_prune_extinct_lineages_polars(
+                    df,
+                    ignore_topological_sensitivity=args.ignore_topological_sensitivity,
+                    drop_topological_sensitivity=args.drop_topological_sensitivity,
+                ),
             )
     except NotImplementedError as e:
         logging.error(

--- a/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
@@ -3,16 +3,18 @@ import pandas as pd
 
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_unfurl_lineage_asexual import alifestd_unfurl_lineage_asexual
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._alifestd_unfurl_lineage_asexual import alifestd_unfurl_lineage_asexual
 from ._pairwise import pairwise
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=False, delete=False, update=True,
+    insert=False,
+    delete=False,
+    update=True,
 )
 def alifestd_reroot_at_id_asexual(
     phylogeny_df: pd.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_reroot_at_id_asexual.py
@@ -5,12 +5,15 @@ from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_unfurl_lineage_asexual import alifestd_unfurl_lineage_asexual
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 from ._pairwise import pairwise
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=False, delete=False, update=True,
+)
 def alifestd_reroot_at_id_asexual(
     phylogeny_df: pd.DataFrame,
     new_root_id: int,
@@ -38,15 +41,6 @@ def alifestd_reroot_at_id_asexual(
     pandas.DataFrame
         The rerooted phylogeny in alife standard format.
     """
-
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_reroot_at_id_asexual",
-        insert=False,
-        delete=False,
-        update=True,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
+++ b/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
@@ -7,8 +7,8 @@ from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_asexual import alifestd_is_asexual
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
 from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
-from ._alifestd_warn_topological_sensitivity import (
-    alifestd_warn_topological_sensitivity,
+from ._alifestd_topological_sensitivity_warned import (
+    alifestd_topological_sensitivity_warned,
 )
 from ._jit import jit
 from ._jit_numba_dict_t import jit_numba_dict_t
@@ -129,6 +129,9 @@ def _alifestd_splay_polytomies_slow_path(
     return phylogeny_df.reset_index(drop=True)
 
 
+@alifestd_topological_sensitivity_warned(
+    insert=True, delete=False, update=True,
+)
 def alifestd_splay_polytomies(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
@@ -162,15 +165,6 @@ def alifestd_splay_polytomies(
     If mutate set True, operation does not occur in place; still use return
     value to get transformed phylogeny dataframe.
     """
-
-    alifestd_warn_topological_sensitivity(
-        phylogeny_df,
-        "alifestd_splay_polytomies",
-        insert=True,
-        delete=False,
-        update=True,
-    )
-
     if not mutate:
         phylogeny_df = phylogeny_df.copy()
 

--- a/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
+++ b/hstrat/_auxiliary_lib/_alifestd_splay_polytomies.py
@@ -6,10 +6,10 @@ import pandas as pd
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_is_asexual import alifestd_is_asexual
 from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
-from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._alifestd_topological_sensitivity_warned import (
     alifestd_topological_sensitivity_warned,
 )
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
 from ._jit import jit
 from ._jit_numba_dict_t import jit_numba_dict_t
 from ._jit_numpy_int64_t import jit_numpy_int64_t
@@ -130,7 +130,9 @@ def _alifestd_splay_polytomies_slow_path(
 
 
 @alifestd_topological_sensitivity_warned(
-    insert=True, delete=False, update=True,
+    insert=True,
+    delete=False,
+    update=True,
 )
 def alifestd_splay_polytomies(
     phylogeny_df: pd.DataFrame,

--- a/hstrat/_auxiliary_lib/_alifestd_topological_sensitivity_warned.py
+++ b/hstrat/_auxiliary_lib/_alifestd_topological_sensitivity_warned.py
@@ -1,5 +1,11 @@
 import functools
+import typing
 
+import pandas as pd
+
+from ._alifestd_drop_topological_sensitivity import (
+    alifestd_drop_topological_sensitivity,
+)
 from ._alifestd_warn_topological_sensitivity import (
     alifestd_warn_topological_sensitivity,
 )
@@ -7,12 +13,20 @@ from ._alifestd_warn_topological_sensitivity import (
 
 def alifestd_topological_sensitivity_warned(
     *, insert: bool, delete: bool, update: bool
-):
+) -> typing.Callable:
     """Decorator that emits a topological sensitivity warning before the
     wrapped function executes.
 
     The first positional argument of the decorated function must be the
     phylogeny dataframe (pandas).
+
+    The decorated function gains two additional keyword arguments:
+
+    - ``ignore_topological_sensitivity`` (bool, default False):
+      If True, suppress the topological sensitivity warning.
+    - ``drop_topological_sensitivity`` (bool, default False):
+      If True, drop topology-sensitive columns from the result and
+      suppress the warning.
 
     Parameters
     ----------
@@ -23,6 +37,12 @@ def alifestd_topological_sensitivity_warned(
     update : bool
         Whether the operation updates ancestor relationships.
 
+    Returns
+    -------
+    typing.Callable
+        A decorator that wraps a function with topological sensitivity
+        warning logic.
+
     See Also
     --------
     alifestd_topological_sensitivity_warned_polars :
@@ -31,17 +51,36 @@ def alifestd_topological_sensitivity_warned(
         Underlying warning function.
     """
 
-    def decorator(func):
+    def decorator(func: typing.Callable) -> typing.Callable:
         @functools.wraps(func)
-        def wrapper(phylogeny_df, *args, **kwargs):
-            alifestd_warn_topological_sensitivity(
-                phylogeny_df,
-                func.__name__,
-                insert=insert,
-                delete=delete,
-                update=update,
-            )
-            return func(phylogeny_df, *args, **kwargs)
+        def wrapper(
+            phylogeny_df: pd.DataFrame,
+            *args: typing.Any,
+            ignore_topological_sensitivity: bool = False,
+            drop_topological_sensitivity: bool = False,
+            **kwargs: typing.Any,
+        ) -> pd.DataFrame:
+            if (
+                not ignore_topological_sensitivity
+                and not drop_topological_sensitivity
+            ):
+                alifestd_warn_topological_sensitivity(
+                    phylogeny_df,
+                    func.__name__,
+                    insert=insert,
+                    delete=delete,
+                    update=update,
+                )
+            result = func(phylogeny_df, *args, **kwargs)
+            if drop_topological_sensitivity:
+                result = alifestd_drop_topological_sensitivity(
+                    result,
+                    mutate=True,
+                    insert=insert,
+                    delete=delete,
+                    update=update,
+                )
+            return result
 
         return wrapper
 

--- a/hstrat/_auxiliary_lib/_alifestd_topological_sensitivity_warned.py
+++ b/hstrat/_auxiliary_lib/_alifestd_topological_sensitivity_warned.py
@@ -1,0 +1,48 @@
+import functools
+
+from ._alifestd_warn_topological_sensitivity import (
+    alifestd_warn_topological_sensitivity,
+)
+
+
+def alifestd_topological_sensitivity_warned(
+    *, insert: bool, delete: bool, update: bool
+):
+    """Decorator that emits a topological sensitivity warning before the
+    wrapped function executes.
+
+    The first positional argument of the decorated function must be the
+    phylogeny dataframe (pandas).
+
+    Parameters
+    ----------
+    insert : bool
+        Whether the operation inserts new nodes.
+    delete : bool
+        Whether the operation deletes nodes.
+    update : bool
+        Whether the operation updates ancestor relationships.
+
+    See Also
+    --------
+    alifestd_topological_sensitivity_warned_polars :
+        Polars-based implementation.
+    alifestd_warn_topological_sensitivity :
+        Underlying warning function.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(phylogeny_df, *args, **kwargs):
+            alifestd_warn_topological_sensitivity(
+                phylogeny_df,
+                func.__name__,
+                insert=insert,
+                delete=delete,
+                update=update,
+            )
+            return func(phylogeny_df, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/hstrat/_auxiliary_lib/_alifestd_topological_sensitivity_warned_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_topological_sensitivity_warned_polars.py
@@ -1,5 +1,11 @@
 import functools
+import typing
 
+import polars as pl
+
+from ._alifestd_drop_topological_sensitivity_polars import (
+    alifestd_drop_topological_sensitivity_polars,
+)
 from ._alifestd_warn_topological_sensitivity_polars import (
     alifestd_warn_topological_sensitivity_polars,
 )
@@ -7,12 +13,20 @@ from ._alifestd_warn_topological_sensitivity_polars import (
 
 def alifestd_topological_sensitivity_warned_polars(
     *, insert: bool, delete: bool, update: bool
-):
+) -> typing.Callable:
     """Decorator that emits a topological sensitivity warning before the
     wrapped function executes.
 
     The first positional argument of the decorated function must be the
     phylogeny dataframe (polars).
+
+    The decorated function gains two additional keyword arguments:
+
+    - ``ignore_topological_sensitivity`` (bool, default False):
+      If True, suppress the topological sensitivity warning.
+    - ``drop_topological_sensitivity`` (bool, default False):
+      If True, drop topology-sensitive columns from the result and
+      suppress the warning.
 
     Parameters
     ----------
@@ -23,6 +37,12 @@ def alifestd_topological_sensitivity_warned_polars(
     update : bool
         Whether the operation updates ancestor relationships.
 
+    Returns
+    -------
+    typing.Callable
+        A decorator that wraps a function with topological sensitivity
+        warning logic.
+
     See Also
     --------
     alifestd_topological_sensitivity_warned :
@@ -31,17 +51,35 @@ def alifestd_topological_sensitivity_warned_polars(
         Underlying warning function.
     """
 
-    def decorator(func):
+    def decorator(func: typing.Callable) -> typing.Callable:
         @functools.wraps(func)
-        def wrapper(phylogeny_df, *args, **kwargs):
-            alifestd_warn_topological_sensitivity_polars(
-                phylogeny_df,
-                func.__name__,
-                insert=insert,
-                delete=delete,
-                update=update,
-            )
-            return func(phylogeny_df, *args, **kwargs)
+        def wrapper(
+            phylogeny_df: typing.Union[pl.DataFrame, pl.LazyFrame],
+            *args: typing.Any,
+            ignore_topological_sensitivity: bool = False,
+            drop_topological_sensitivity: bool = False,
+            **kwargs: typing.Any,
+        ) -> typing.Union[pl.DataFrame, pl.LazyFrame]:
+            if (
+                not ignore_topological_sensitivity
+                and not drop_topological_sensitivity
+            ):
+                alifestd_warn_topological_sensitivity_polars(
+                    phylogeny_df,
+                    func.__name__,
+                    insert=insert,
+                    delete=delete,
+                    update=update,
+                )
+            result = func(phylogeny_df, *args, **kwargs)
+            if drop_topological_sensitivity:
+                result = alifestd_drop_topological_sensitivity_polars(
+                    result,
+                    insert=insert,
+                    delete=delete,
+                    update=update,
+                )
+            return result
 
         return wrapper
 

--- a/hstrat/_auxiliary_lib/_alifestd_topological_sensitivity_warned_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_topological_sensitivity_warned_polars.py
@@ -1,0 +1,48 @@
+import functools
+
+from ._alifestd_warn_topological_sensitivity_polars import (
+    alifestd_warn_topological_sensitivity_polars,
+)
+
+
+def alifestd_topological_sensitivity_warned_polars(
+    *, insert: bool, delete: bool, update: bool
+):
+    """Decorator that emits a topological sensitivity warning before the
+    wrapped function executes.
+
+    The first positional argument of the decorated function must be the
+    phylogeny dataframe (polars).
+
+    Parameters
+    ----------
+    insert : bool
+        Whether the operation inserts new nodes.
+    delete : bool
+        Whether the operation deletes nodes.
+    update : bool
+        Whether the operation updates ancestor relationships.
+
+    See Also
+    --------
+    alifestd_topological_sensitivity_warned :
+        Pandas-based implementation.
+    alifestd_warn_topological_sensitivity_polars :
+        Underlying warning function.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(phylogeny_df, *args, **kwargs):
+            alifestd_warn_topological_sensitivity_polars(
+                phylogeny_df,
+                func.__name__,
+                insert=insert,
+                delete=delete,
+                update=update,
+            )
+            return func(phylogeny_df, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -18,7 +18,11 @@ def _alifestd_warn_topological_sensitivity(
     update: bool,
 ) -> None:
     """Private helper: emit a warning listing invalidated columns."""
-    if invalidated and "HSTRAT_ALIFESTD_WARN_TOPOLOGICAL_SENSITIVITY_SUPPRESS" not in os.environ:
+    if (
+        invalidated
+        and "HSTRAT_ALIFESTD_WARN_TOPOLOGICAL_SENSITIVITY_SUPPRESS"
+        not in os.environ
+    ):
         ops = "/".join(
             name
             for flag, name in [

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -1,3 +1,4 @@
+import os
 import typing
 import warnings
 
@@ -17,6 +18,10 @@ def _alifestd_warn_topological_sensitivity(
     update: bool,
 ) -> None:
     """Private helper: emit a warning listing invalidated columns."""
+    if os.environ.get(
+        "HSTRAT_ALIFESTD_WARN_TOPOLOGICAL_SENSITIVITY_SUPPRESS",
+    ):
+        return
     if invalidated:
         ops = "/".join(
             name
@@ -33,7 +38,9 @@ def _alifestd_warn_topological_sensitivity(
             f"{invalidated}. "
             "Use `origin_time` to recalculate branch lengths for "
             "collapsed phylogeny. To silence this warning, use "
-            "alifestd_drop_topological_sensitivity{_polars}."
+            "alifestd_drop_topological_sensitivity{_polars} or set "
+            "HSTRAT_ALIFESTD_WARN_TOPOLOGICAL_SENSITIVITY_SUPPRESS "
+            "in environ."
         )
 
 

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -40,7 +40,7 @@ def _alifestd_warn_topological_sensitivity(
             "collapsed phylogeny. To silence this warning, use "
             "alifestd_drop_topological_sensitivity{_polars} or set "
             "HSTRAT_ALIFESTD_WARN_TOPOLOGICAL_SENSITIVITY_SUPPRESS "
-            "in environ."
+            "environment variable."
         )
 
 

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -18,9 +18,7 @@ def _alifestd_warn_topological_sensitivity(
     update: bool,
 ) -> None:
     """Private helper: emit a warning listing invalidated columns."""
-    if "HSTRAT_ALIFESTD_WARN_TOPOLOGICAL_SENSITIVITY_SUPPRESS" in os.environ:
-        return
-    if invalidated:
+    if invalidated and "HSTRAT_ALIFESTD_WARN_TOPOLOGICAL_SENSITIVITY_SUPPRESS" not in os.environ:
         ops = "/".join(
             name
             for flag, name in [

--- a/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
+++ b/hstrat/_auxiliary_lib/_alifestd_warn_topological_sensitivity.py
@@ -18,9 +18,7 @@ def _alifestd_warn_topological_sensitivity(
     update: bool,
 ) -> None:
     """Private helper: emit a warning listing invalidated columns."""
-    if os.environ.get(
-        "HSTRAT_ALIFESTD_WARN_TOPOLOGICAL_SENSITIVITY_SUPPRESS",
-    ):
+    if "HSTRAT_ALIFESTD_WARN_TOPOLOGICAL_SENSITIVITY_SUPPRESS" in os.environ:
         return
     if invalidated:
         ops = "/".join(

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root_cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import subprocess
 
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
@@ -28,8 +29,9 @@ def test_alifestd_add_global_root_cli_version():
     )
 
 
-def test_alifestd_add_global_root_cli_csv(tmp_path):
-    output_file = str(tmp_path / "hstrat_alifestd_add_global_root.csv")
+def test_alifestd_add_global_root_cli_csv():
+    output_file = "/tmp/hstrat_alifestd_add_global_root.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -44,8 +46,9 @@ def test_alifestd_add_global_root_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_add_global_root_cli_parquet(tmp_path):
-    output_file = str(tmp_path / "hstrat_alifestd_add_global_root.pqt")
+def test_alifestd_add_global_root_cli_parquet():
+    output_file = "/tmp/hstrat_alifestd_add_global_root.pqt"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -60,10 +63,9 @@ def test_alifestd_add_global_root_cli_parquet(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_add_global_root_cli_ignore_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_add_global_root_cli_ignore_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_add_global_root_ignore.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -79,8 +81,9 @@ def test_alifestd_add_global_root_cli_ignore_topological_sensitivity(
     assert os.path.exists(output_file)
 
 
-def test_alifestd_add_global_root_cli_drop_topological_sensitivity(tmp_path):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_add_global_root_cli_drop_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_add_global_root_drop.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_global_root_cli.py
@@ -58,3 +58,39 @@ def test_alifestd_add_global_root_cli_parquet(tmp_path):
         input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
     )
     assert os.path.exists(output_file)
+
+
+def test_alifestd_add_global_root_cli_ignore_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_add_global_root",
+            "--ignore-topological-sensitivity",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_add_global_root_cli_drop_topological_sensitivity(tmp_path):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_add_global_root",
+            "--drop-topological-sensitivity",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_inner_leaves_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_add_inner_leaves_cli.py
@@ -59,3 +59,37 @@ def test_alifestd_add_inner_leaves_cli_parquet():
         input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
     )
     assert os.path.exists(output_file)
+
+
+def test_alifestd_add_inner_leaves_cli_ignore_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_add_inner_leaves_ignore.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_add_inner_leaves",
+            "--ignore-topological-sensitivity",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_add_inner_leaves_cli_drop_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_add_inner_leaves_drop.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_add_inner_leaves",
+            "--drop-topological-sensitivity",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_collapse_unifurcations_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_collapse_unifurcations_cli.py
@@ -58,3 +58,41 @@ def test_alifestd_collapse_unifurcations_cli_parquet(tmp_path):
         input=f"{assets}/collapse_unifurcations_testphylo.csv".encode(),
     )
     assert os.path.exists(output_file)
+
+
+def test_alifestd_collapse_unifurcations_cli_ignore_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_collapse_unifurcations",
+            "--ignore-topological-sensitivity",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/collapse_unifurcations_testphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_collapse_unifurcations_cli_drop_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_collapse_unifurcations",
+            "--drop-topological-sensitivity",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/collapse_unifurcations_testphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_collapse_unifurcations_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_collapse_unifurcations_cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import subprocess
 
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
@@ -28,8 +29,9 @@ def test_alifestd_collapse_unifurcations_cli_version():
     )
 
 
-def test_alifestd_collapse_unifurcations_cli_csv(tmp_path):
-    output_file = str(tmp_path / "hstrat_alifestd_collapse_unifurcations.csv")
+def test_alifestd_collapse_unifurcations_cli_csv():
+    output_file = "/tmp/hstrat_alifestd_collapse_unifurcations.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -44,8 +46,9 @@ def test_alifestd_collapse_unifurcations_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_collapse_unifurcations_cli_parquet(tmp_path):
-    output_file = str(tmp_path / "hstrat_alifestd_collapse_unifurcations.pqt")
+def test_alifestd_collapse_unifurcations_cli_parquet():
+    output_file = "/tmp/hstrat_alifestd_collapse_unifurcations.pqt"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -60,10 +63,9 @@ def test_alifestd_collapse_unifurcations_cli_parquet(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_collapse_unifurcations_cli_ignore_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_collapse_unifurcations_cli_ignore_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_collapse_unifurcations_ignore.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -79,10 +81,9 @@ def test_alifestd_collapse_unifurcations_cli_ignore_topological_sensitivity(
     assert os.path.exists(output_file)
 
 
-def test_alifestd_collapse_unifurcations_cli_drop_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_collapse_unifurcations_cli_drop_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_collapse_unifurcations_drop.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_collapse_unifurcations_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_collapse_unifurcations_polars_cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import subprocess
 
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
@@ -28,10 +29,11 @@ def test_alifestd_collapse_unifurcations_polars_cli_version():
     )
 
 
-def test_alifestd_collapse_unifurcations_polars_cli_csv(tmp_path):
-    output_file = str(
-        tmp_path / "hstrat_alifestd_collapse_unifurcations_polars.csv"
+def test_alifestd_collapse_unifurcations_polars_cli_csv():
+    output_file = (
+        "/tmp/hstrat_alifestd_collapse_unifurcations_polars.csv"
     )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -46,10 +48,11 @@ def test_alifestd_collapse_unifurcations_polars_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_collapse_unifurcations_polars_cli_parquet(tmp_path):
-    output_file = str(
-        tmp_path / "hstrat_alifestd_collapse_unifurcations_polars.pqt"
+def test_alifestd_collapse_unifurcations_polars_cli_parquet():
+    output_file = (
+        "/tmp/hstrat_alifestd_collapse_unifurcations_polars.pqt"
     )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -64,10 +67,11 @@ def test_alifestd_collapse_unifurcations_polars_cli_parquet(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_collapse_unifurcations_polars_cli_ignore_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_collapse_unifurcations_polars_cli_ignore_topological_sensitivity():
+    output_file = (
+        "/tmp/hstrat_alifestd_collapse_unifurcations_polars_ignore.csv"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -83,10 +87,11 @@ def test_alifestd_collapse_unifurcations_polars_cli_ignore_topological_sensitivi
     assert os.path.exists(output_file)
 
 
-def test_alifestd_collapse_unifurcations_polars_cli_drop_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_collapse_unifurcations_polars_cli_drop_topological_sensitivity():
+    output_file = (
+        "/tmp/hstrat_alifestd_collapse_unifurcations_polars_drop.csv"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_collapse_unifurcations_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_collapse_unifurcations_polars_cli.py
@@ -62,3 +62,41 @@ def test_alifestd_collapse_unifurcations_polars_cli_parquet(tmp_path):
         input=f"{assets}/collapse_unifurcations_testphylo.csv".encode(),
     )
     assert os.path.exists(output_file)
+
+
+def test_alifestd_collapse_unifurcations_polars_cli_ignore_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_collapse_unifurcations_polars",
+            "--ignore-topological-sensitivity",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/collapse_unifurcations_testphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_collapse_unifurcations_polars_cli_drop_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_collapse_unifurcations_polars",
+            "--drop-topological-sensitivity",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/collapse_unifurcations_testphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_collapse_unifurcations_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_collapse_unifurcations_polars_cli.py
@@ -30,9 +30,7 @@ def test_alifestd_collapse_unifurcations_polars_cli_version():
 
 
 def test_alifestd_collapse_unifurcations_polars_cli_csv():
-    output_file = (
-        "/tmp/hstrat_alifestd_collapse_unifurcations_polars.csv"
-    )
+    output_file = "/tmp/hstrat_alifestd_collapse_unifurcations_polars.csv"
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
@@ -49,9 +47,7 @@ def test_alifestd_collapse_unifurcations_polars_cli_csv():
 
 
 def test_alifestd_collapse_unifurcations_polars_cli_parquet():
-    output_file = (
-        "/tmp/hstrat_alifestd_collapse_unifurcations_polars.pqt"
-    )
+    output_file = "/tmp/hstrat_alifestd_collapse_unifurcations_polars.pqt"
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
@@ -88,9 +84,7 @@ def test_alifestd_collapse_unifurcations_polars_cli_ignore_topological_sensitivi
 
 
 def test_alifestd_collapse_unifurcations_polars_cli_drop_topological_sensitivity():
-    output_file = (
-        "/tmp/hstrat_alifestd_collapse_unifurcations_polars_drop.csv"
-    )
+    output_file = "/tmp/hstrat_alifestd_collapse_unifurcations_polars_drop.csv"
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_asexual_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_asexual_cli.py
@@ -65,3 +65,41 @@ def test_alifestd_downsample_tips_asexual_cli_parquet():
         input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
     )
     assert os.path.exists(output_file)
+
+
+def test_alifestd_downsample_tips_asexual_cli_ignore_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_asexual_ignore.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_asexual",
+            "-n",
+            "1",
+            "--ignore-topological-sensitivity",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_downsample_tips_asexual_cli_drop_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_asexual_drop.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_asexual",
+            "-n",
+            "1",
+            "--drop-topological-sensitivity",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_clade_asexual_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_clade_asexual_cli.py
@@ -65,3 +65,43 @@ def test_alifestd_downsample_tips_clade_asexual_cli_parquet():
         input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
     )
     assert os.path.exists(output_file)
+
+
+def test_alifestd_downsample_tips_clade_asexual_cli_ignore_topological_sensitivity():
+    output_file = (
+        "/tmp/hstrat_alifestd_downsample_tips_clade_asexual_ignore.csv"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_clade_asexual",
+            "-n",
+            "1",
+            "--ignore-topological-sensitivity",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_downsample_tips_clade_asexual_cli_drop_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_clade_asexual_drop.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_clade_asexual",
+            "-n",
+            "1",
+            "--drop-topological-sensitivity",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_polars_cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import subprocess
 
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
@@ -28,8 +29,9 @@ def test_alifestd_downsample_tips_polars_cli_version():
     )
 
 
-def test_alifestd_downsample_tips_polars_cli_csv(tmp_path):
-    output_file = str(tmp_path / "hstrat_alifestd_downsample_tips_polars.csv")
+def test_alifestd_downsample_tips_polars_cli_csv():
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_polars.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -46,8 +48,9 @@ def test_alifestd_downsample_tips_polars_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_downsample_tips_polars_cli_empty(tmp_path):
-    output_file = str(tmp_path / "hstrat_alifestd_downsample_tips_polars.csv")
+def test_alifestd_downsample_tips_polars_cli_empty():
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_polars_empty.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -63,10 +66,11 @@ def test_alifestd_downsample_tips_polars_cli_empty(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_downsample_tips_polars_cli_ignore_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_downsample_tips_polars_cli_ignore_topological_sensitivity():
+    output_file = (
+        "/tmp/hstrat_alifestd_downsample_tips_polars_ignore.csv"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -84,10 +88,11 @@ def test_alifestd_downsample_tips_polars_cli_ignore_topological_sensitivity(
     assert os.path.exists(output_file)
 
 
-def test_alifestd_downsample_tips_polars_cli_drop_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_downsample_tips_polars_cli_drop_topological_sensitivity():
+    output_file = (
+        "/tmp/hstrat_alifestd_downsample_tips_polars_drop.csv"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_polars_cli.py
@@ -61,3 +61,45 @@ def test_alifestd_downsample_tips_polars_cli_empty(tmp_path):
         input=f"{assets}/empty.csv".encode(),
     )
     assert os.path.exists(output_file)
+
+
+def test_alifestd_downsample_tips_polars_cli_ignore_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_polars",
+            "-n",
+            "4",
+            "--ignore-topological-sensitivity",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/trunktestphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_downsample_tips_polars_cli_drop_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_polars",
+            "-n",
+            "4",
+            "--drop-topological-sensitivity",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/trunktestphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_polars_cli.py
@@ -67,9 +67,7 @@ def test_alifestd_downsample_tips_polars_cli_empty():
 
 
 def test_alifestd_downsample_tips_polars_cli_ignore_topological_sensitivity():
-    output_file = (
-        "/tmp/hstrat_alifestd_downsample_tips_polars_ignore.csv"
-    )
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_polars_ignore.csv"
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
@@ -89,9 +87,7 @@ def test_alifestd_downsample_tips_polars_cli_ignore_topological_sensitivity():
 
 
 def test_alifestd_downsample_tips_polars_cli_drop_topological_sensitivity():
-    output_file = (
-        "/tmp/hstrat_alifestd_downsample_tips_polars_drop.csv"
-    )
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_polars_drop.csv"
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_join_roots_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_join_roots_cli.py
@@ -59,3 +59,37 @@ def test_alifestd_join_roots_cli_parquet():
         input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
     )
     assert os.path.exists(output_file)
+
+
+def test_alifestd_join_roots_cli_ignore_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_join_roots_ignore.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_join_roots",
+            "--ignore-topological-sensitivity",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_join_roots_cli_drop_topological_sensitivity():
+    output_file = "/tmp/hstrat_alifestd_join_roots_drop.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_join_roots",
+            "--drop-topological-sensitivity",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/example-standard-toy-asexual-phylogeny.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_mark_leaves_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_mark_leaves_cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import subprocess
 
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
@@ -28,8 +29,9 @@ def test_alifestd_mark_leaves_cli_version():
     )
 
 
-def test_alifestd_mark_leaves_cli_csv(tmp_path):
-    output_file = str(tmp_path / "hstrat_alifestd_mark_leaves.csv")
+def test_alifestd_mark_leaves_cli_csv():
+    output_file = "/tmp/hstrat_alifestd_mark_leaves.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -43,8 +45,9 @@ def test_alifestd_mark_leaves_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_mark_leaves_cli_parquet(tmp_path):
-    output_file = str(tmp_path / "hstrat_alifestd_mark_leaves.pqt")
+def test_alifestd_mark_leaves_cli_parquet():
+    output_file = "/tmp/hstrat_alifestd_mark_leaves.pqt"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_mark_leaves_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_mark_leaves_polars_cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import subprocess
 
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
@@ -28,8 +29,9 @@ def test_alifestd_mark_leaves_polars_cli_version():
     )
 
 
-def test_alifestd_mark_leaves_polars_cli_csv(tmp_path):
-    output_file = str(tmp_path / "hstrat_alifestd_mark_leaves_polars.csv")
+def test_alifestd_mark_leaves_polars_cli_csv():
+    output_file = "/tmp/hstrat_alifestd_mark_leaves_polars.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -44,8 +46,9 @@ def test_alifestd_mark_leaves_polars_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_mark_leaves_polars_cli_empty(tmp_path):
-    output_file = str(tmp_path / "hstrat_alifestd_mark_leaves_polars.csv")
+def test_alifestd_mark_leaves_polars_cli_empty():
+    output_file = "/tmp/hstrat_alifestd_mark_leaves_polars_empty.csv"
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_asexual_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_asexual_cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import subprocess
 
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
@@ -28,10 +29,11 @@ def test_alifestd_prune_extinct_lineages_asexual_cli_version():
     )
 
 
-def test_alifestd_prune_extinct_lineages_asexual_cli_csv(tmp_path):
-    output_file = str(
-        tmp_path / "hstrat_alifestd_prune_extinct_lineages_asexual.csv"
+def test_alifestd_prune_extinct_lineages_asexual_cli_csv():
+    output_file = (
+        "/tmp/hstrat_alifestd_prune_extinct_lineages_asexual.csv"
     )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -45,10 +47,11 @@ def test_alifestd_prune_extinct_lineages_asexual_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_prune_extinct_lineages_asexual_cli_parquet(tmp_path):
-    output_file = str(
-        tmp_path / "hstrat_alifestd_prune_extinct_lineages_asexual.pqt"
+def test_alifestd_prune_extinct_lineages_asexual_cli_parquet():
+    output_file = (
+        "/tmp/hstrat_alifestd_prune_extinct_lineages_asexual.pqt"
     )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -62,10 +65,11 @@ def test_alifestd_prune_extinct_lineages_asexual_cli_parquet(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_prune_extinct_lineages_asexual_cli_ignore_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_prune_extinct_lineages_asexual_cli_ignore_topological_sensitivity():
+    output_file = (
+        "/tmp/hstrat_alifestd_prune_extinct_lineages_asexual_ignore.csv"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -80,10 +84,11 @@ def test_alifestd_prune_extinct_lineages_asexual_cli_ignore_topological_sensitiv
     assert os.path.exists(output_file)
 
 
-def test_alifestd_prune_extinct_lineages_asexual_cli_drop_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_prune_extinct_lineages_asexual_cli_drop_topological_sensitivity():
+    output_file = (
+        "/tmp/hstrat_alifestd_prune_extinct_lineages_asexual_drop.csv"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_asexual_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_asexual_cli.py
@@ -60,3 +60,39 @@ def test_alifestd_prune_extinct_lineages_asexual_cli_parquet(tmp_path):
         input=f"{assets}/nk_ecoeaselection.csv".encode(),
     )
     assert os.path.exists(output_file)
+
+
+def test_alifestd_prune_extinct_lineages_asexual_cli_ignore_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_prune_extinct_lineages_asexual",
+            "--ignore-topological-sensitivity",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/nk_ecoeaselection.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_prune_extinct_lineages_asexual_cli_drop_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_prune_extinct_lineages_asexual",
+            "--drop-topological-sensitivity",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/nk_ecoeaselection.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_asexual_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_asexual_cli.py
@@ -30,9 +30,7 @@ def test_alifestd_prune_extinct_lineages_asexual_cli_version():
 
 
 def test_alifestd_prune_extinct_lineages_asexual_cli_csv():
-    output_file = (
-        "/tmp/hstrat_alifestd_prune_extinct_lineages_asexual.csv"
-    )
+    output_file = "/tmp/hstrat_alifestd_prune_extinct_lineages_asexual.csv"
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
@@ -48,9 +46,7 @@ def test_alifestd_prune_extinct_lineages_asexual_cli_csv():
 
 
 def test_alifestd_prune_extinct_lineages_asexual_cli_parquet():
-    output_file = (
-        "/tmp/hstrat_alifestd_prune_extinct_lineages_asexual.pqt"
-    )
+    output_file = "/tmp/hstrat_alifestd_prune_extinct_lineages_asexual.pqt"
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_polars_cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import subprocess
 
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
@@ -28,10 +29,11 @@ def test_alifestd_prune_extinct_lineages_polars_cli_version():
     )
 
 
-def test_alifestd_prune_extinct_lineages_polars_cli_csv(tmp_path):
-    output_file = str(
-        tmp_path / "hstrat_alifestd_prune_extinct_lineages_polars.csv"
+def test_alifestd_prune_extinct_lineages_polars_cli_csv():
+    output_file = (
+        "/tmp/hstrat_alifestd_prune_extinct_lineages_polars.csv"
     )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -46,10 +48,11 @@ def test_alifestd_prune_extinct_lineages_polars_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_prune_extinct_lineages_polars_cli_empty(tmp_path):
-    output_file = str(
-        tmp_path / "hstrat_alifestd_prune_extinct_lineages_polars.csv"
+def test_alifestd_prune_extinct_lineages_polars_cli_empty():
+    output_file = (
+        "/tmp/hstrat_alifestd_prune_extinct_lineages_polars_empty.csv"
     )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -63,10 +66,11 @@ def test_alifestd_prune_extinct_lineages_polars_cli_empty(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_prune_extinct_lineages_polars_cli_ignore_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_prune_extinct_lineages_polars_cli_ignore_topological_sensitivity():
+    output_file = (
+        "/tmp/hstrat_alifestd_prune_extinct_lineages_polars_ignore.csv"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -82,10 +86,11 @@ def test_alifestd_prune_extinct_lineages_polars_cli_ignore_topological_sensitivi
     assert os.path.exists(output_file)
 
 
-def test_alifestd_prune_extinct_lineages_polars_cli_drop_topological_sensitivity(
-    tmp_path,
-):
-    output_file = str(tmp_path / "output.csv")
+def test_alifestd_prune_extinct_lineages_polars_cli_drop_topological_sensitivity():
+    output_file = (
+        "/tmp/hstrat_alifestd_prune_extinct_lineages_polars_drop.csv"
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_polars_cli.py
@@ -61,3 +61,41 @@ def test_alifestd_prune_extinct_lineages_polars_cli_empty(tmp_path):
         input=f"{assets}/empty.csv".encode(),
     )
     assert os.path.exists(output_file)
+
+
+def test_alifestd_prune_extinct_lineages_polars_cli_ignore_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_prune_extinct_lineages_polars",
+            "--ignore-topological-sensitivity",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/prunetestphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
+def test_alifestd_prune_extinct_lineages_polars_cli_drop_topological_sensitivity(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output.csv")
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat._auxiliary_lib._alifestd_prune_extinct_lineages_polars",
+            "--drop-topological-sensitivity",
+            "--eager-write",
+            output_file,
+        ],
+        check=True,
+        input=f"{assets}/prunetestphylo.csv".encode(),
+    )
+    assert os.path.exists(output_file)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_prune_extinct_lineages_polars_cli.py
@@ -30,9 +30,7 @@ def test_alifestd_prune_extinct_lineages_polars_cli_version():
 
 
 def test_alifestd_prune_extinct_lineages_polars_cli_csv():
-    output_file = (
-        "/tmp/hstrat_alifestd_prune_extinct_lineages_polars.csv"
-    )
+    output_file = "/tmp/hstrat_alifestd_prune_extinct_lineages_polars.csv"
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
@@ -87,9 +85,7 @@ def test_alifestd_prune_extinct_lineages_polars_cli_ignore_topological_sensitivi
 
 
 def test_alifestd_prune_extinct_lineages_polars_cli_drop_topological_sensitivity():
-    output_file = (
-        "/tmp/hstrat_alifestd_prune_extinct_lineages_polars_drop.csv"
-    )
+    output_file = "/tmp/hstrat_alifestd_prune_extinct_lineages_polars_drop.csv"
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_try_add_ancestor_list_col_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_try_add_ancestor_list_col_polars_cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import subprocess
 
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
@@ -28,10 +29,11 @@ def test_alifestd_try_add_ancestor_list_col_polars_cli_version():
     )
 
 
-def test_alifestd_try_add_ancestor_list_col_polars_cli_csv(tmp_path):
-    output_file = str(
-        tmp_path / "hstrat_alifestd_try_add_ancestor_list_col_polars.csv"
+def test_alifestd_try_add_ancestor_list_col_polars_cli_csv():
+    output_file = (
+        "/tmp/hstrat_alifestd_try_add_ancestor_list_col_polars.csv"
     )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
@@ -46,10 +48,11 @@ def test_alifestd_try_add_ancestor_list_col_polars_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_try_add_ancestor_list_col_polars_cli_empty(tmp_path):
-    output_file = str(
-        tmp_path / "hstrat_alifestd_try_add_ancestor_list_col_polars.csv"
+def test_alifestd_try_add_ancestor_list_col_polars_cli_empty():
+    output_file = (
+        "/tmp/hstrat_alifestd_try_add_ancestor_list_col_polars_empty.csv"
     )
+    pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_try_add_ancestor_list_col_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_try_add_ancestor_list_col_polars_cli.py
@@ -30,9 +30,7 @@ def test_alifestd_try_add_ancestor_list_col_polars_cli_version():
 
 
 def test_alifestd_try_add_ancestor_list_col_polars_cli_csv():
-    output_file = (
-        "/tmp/hstrat_alifestd_try_add_ancestor_list_col_polars.csv"
-    )
+    output_file = "/tmp/hstrat_alifestd_try_add_ancestor_list_col_polars.csv"
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [


### PR DESCRIPTION
Add the topological sensitivity warning call to 16 alifestd functions that
modify tree topology (insert/delete/update) but were missing the warning.
This ensures users are alerted when topology-dependent columns (e.g.,
branch_length, num_children, num_leaves) may be invalidated.

Functions updated (pandas):
- alifestd_add_inner_knuckles_asexual (insert+update)
- alifestd_add_inner_leaves (insert)
- alifestd_add_inner_niblings_asexual (insert+update)
- alifestd_coarsen_taxa_asexual (delete+update)
- alifestd_collapse_trunk_asexual (delete+update)
- alifestd_delete_trunk_asexual (delete+update)
- alifestd_delete_unifurcating_roots_asexual (delete+update)
- alifestd_downsample_tips_asexual (delete)
- alifestd_downsample_tips_clade_asexual (delete)
- alifestd_join_roots (update)
- alifestd_prefix_roots (insert+update)
- alifestd_prune_extinct_lineages_asexual (delete)

Functions updated (polars):
- alifestd_delete_trunk_asexual_polars (delete+update)
- alifestd_downsample_tips_polars (delete)
- alifestd_prefix_roots_polars (insert+update)
- alifestd_prune_extinct_lineages_polars (delete)

https://claude.ai/code/session_01J1KDaMygr4qJtCpfsBEied