### PR TITLE
Cache OSF genome data in CLI tests to improve performance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
+    - name: Cache OSF genome data
+      uses: actions/cache@v4
+      with:
+        path: /tmp/hstrat-gnkbc.pqt
+        key: osf-gnkbc
     - name: Install Python dependencies
       uses: py-actions/py-dependency-install@v4
       with:

--- a/tests-cli/test_dataframe_surface_build_tree_cmp.sh
+++ b/tests-cli/test_dataframe_surface_build_tree_cmp.sh
@@ -25,7 +25,7 @@ trap err ERR
 # get example genome data
 cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
     || { wget -O "${genomes}" https://osf.io/gnkbc/download \
-    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    > "${HSTRAT_TESTS_CLI_STDOUT}" 2>&1 \
     && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 echo "BEGIN $0"

--- a/tests-cli/test_dataframe_surface_build_tree_cmp.sh
+++ b/tests-cli/test_dataframe_surface_build_tree_cmp.sh
@@ -23,8 +23,10 @@ err() {
 trap err ERR
 
 # get example genome data
-wget -O "${genomes}" https://osf.io/gnkbc/download \
-    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1
+cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
+    || { wget -O "${genomes}" https://osf.io/gnkbc/download \
+    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 echo "BEGIN $0"
 echo "/ HSTRAT_TESTS_CLI_STDOUT=${HSTRAT_TESTS_CLI_STDOUT}"

--- a/tests-cli/test_dataframe_surface_build_tree_iso.sh
+++ b/tests-cli/test_dataframe_surface_build_tree_iso.sh
@@ -23,8 +23,10 @@ err() {
 trap err ERR
 
 # get example genome data
-wget -O "${genomes}" https://osf.io/gnkbc/download \
-    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1
+cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
+    || { wget -O "${genomes}" https://osf.io/gnkbc/download \
+    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 # unpack and reconstruct reference
 ls -1 "${genomes}" \

--- a/tests-cli/test_dataframe_surface_build_tree_iso.sh
+++ b/tests-cli/test_dataframe_surface_build_tree_iso.sh
@@ -25,7 +25,7 @@ trap err ERR
 # get example genome data
 cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
     || { wget -O "${genomes}" https://osf.io/gnkbc/download \
-    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    > "${HSTRAT_TESTS_CLI_STDOUT}" 2>&1 \
     && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 # unpack and reconstruct reference

--- a/tests-cli/test_dataframe_surface_build_tree_iso___no_delete_trunk.sh
+++ b/tests-cli/test_dataframe_surface_build_tree_iso___no_delete_trunk.sh
@@ -23,8 +23,10 @@ err() {
 trap err ERR
 
 # get example genome data
-wget -O "${genomes}" https://osf.io/gnkbc/download \
-    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1
+cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
+    || { wget -O "${genomes}" https://osf.io/gnkbc/download \
+    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 # unpack and reconstruct reference
 ls -1 "${genomes}" \

--- a/tests-cli/test_dataframe_surface_build_tree_iso___no_delete_trunk.sh
+++ b/tests-cli/test_dataframe_surface_build_tree_iso___no_delete_trunk.sh
@@ -25,7 +25,7 @@ trap err ERR
 # get example genome data
 cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
     || { wget -O "${genomes}" https://osf.io/gnkbc/download \
-    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    > "${HSTRAT_TESTS_CLI_STDOUT}" 2>&1 \
     && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 # unpack and reconstruct reference

--- a/tests-cli/test_dataframe_surface_postprocess_trie_cmp.sh
+++ b/tests-cli/test_dataframe_surface_postprocess_trie_cmp.sh
@@ -27,7 +27,7 @@ trap err ERR
 # get example genome data
 cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
     || { wget -O "${genomes}" https://osf.io/gnkbc/download \
-    >${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    >"${HSTRAT_TESTS_CLI_STDOUT}" 2>&1 \
     && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 # unpack and reconstruct

--- a/tests-cli/test_dataframe_surface_postprocess_trie_cmp.sh
+++ b/tests-cli/test_dataframe_surface_postprocess_trie_cmp.sh
@@ -25,8 +25,10 @@ err() {
 trap err ERR
 
 # get example genome data
-wget -O "${genomes}" https://osf.io/gnkbc/download \
-    >${HSTRAT_TESTS_CLI_STDOUT} 2>&1
+cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
+    || { wget -O "${genomes}" https://osf.io/gnkbc/download \
+    >${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 # unpack and reconstruct
 ls -1 "${genomes}" \

--- a/tests-cli/test_dataframe_surface_unpack_reconstruct_cmp.sh
+++ b/tests-cli/test_dataframe_surface_unpack_reconstruct_cmp.sh
@@ -25,7 +25,7 @@ trap err ERR
 # get example genome data
 cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
     || { wget -O "${genomes}" https://osf.io/gnkbc/download \
-    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    > "${HSTRAT_TESTS_CLI_STDOUT}" 2>&1 \
     && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 echo "BEGIN $0"

--- a/tests-cli/test_dataframe_surface_unpack_reconstruct_cmp.sh
+++ b/tests-cli/test_dataframe_surface_unpack_reconstruct_cmp.sh
@@ -23,8 +23,10 @@ err() {
 trap err ERR
 
 # get example genome data
-wget -O "${genomes}" https://osf.io/gnkbc/download \
-    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1
+cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
+    || { wget -O "${genomes}" https://osf.io/gnkbc/download \
+    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 echo "BEGIN $0"
 echo "/ HSTRAT_TESTS_CLI_STDOUT=${HSTRAT_TESTS_CLI_STDOUT}"

--- a/tests-cli/test_dataframe_surface_unpack_reconstruct_iso.sh
+++ b/tests-cli/test_dataframe_surface_unpack_reconstruct_iso.sh
@@ -23,8 +23,10 @@ err() {
 trap err ERR
 
 # get example genome data
-wget -O "${genomes}" https://osf.io/gnkbc/download \
-    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1
+cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
+    || { wget -O "${genomes}" https://osf.io/gnkbc/download \
+    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 # unpack and reconstruct reference
 ls -1 "${genomes}" \

--- a/tests-cli/test_dataframe_surface_unpack_reconstruct_iso.sh
+++ b/tests-cli/test_dataframe_surface_unpack_reconstruct_iso.sh
@@ -25,7 +25,7 @@ trap err ERR
 # get example genome data
 cp /tmp/hstrat-gnkbc.pqt "${genomes}" 2>/dev/null \
     || { wget -O "${genomes}" https://osf.io/gnkbc/download \
-    > ${HSTRAT_TESTS_CLI_STDOUT} 2>&1 \
+    > "${HSTRAT_TESTS_CLI_STDOUT}" 2>&1 \
     && cp "${genomes}" /tmp/hstrat-gnkbc.pqt; }
 
 # unpack and reconstruct reference


### PR DESCRIPTION
## Summary
This PR improves the efficiency of CLI tests by implementing a caching mechanism for the example genome data downloaded from OSF. Instead of downloading the file on every test run, tests now check for a cached copy first and only download if necessary.

## Key Changes
- **Updated 6 CLI test scripts** to use a two-step approach:
  - First attempt to copy cached genome data from `/tmp/hstrat-gnkbc.pqt`
  - Fall back to downloading from OSF if cache doesn't exist
  - Cache the downloaded file for future test runs
  
- **Added GitHub Actions cache step** in CI workflow to persist the cached genome data across workflow runs, reducing redundant downloads and improving CI performance

## Implementation Details
- The cache fallback pattern uses shell's `||` operator to gracefully handle missing cache files
- After successful download, the file is copied to `/tmp/hstrat-gnkbc.pqt` for subsequent test runs
- GitHub Actions cache with key `osf-gnkbc` ensures the cached file persists between CI runs
- All affected test files follow the same caching pattern for consistency

https://claude.ai/code/session_01JkTqxC8xwyVJMHMzuJ1zWy