### PR TITLE
Rename downsample_canopy functions to downsample_tips_canopy

### DIFF
--- a/hstrat/__main__.py
+++ b/hstrat/__main__.py
@@ -24,8 +24,8 @@ $ python3 -m hstrat._auxiliary_lib._alifestd_drop_topological_sensitivity_polars
 $ python3 -m hstrat._auxiliary_lib._alifestd_join_roots
 $ python3 -m hstrat._auxiliary_lib._alifestd_mark_leaves
 $ python3 -m hstrat._auxiliary_lib._alifestd_mark_leaves_polars
-$ python3 -m hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual
-$ python3 -m hstrat._auxiliary_lib._alifestd_downsample_canopy_polars
+$ python3 -m hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual
+$ python3 -m hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars
 $ python3 -m hstrat._auxiliary_lib._alifestd_prune_extinct_lineages_asexual
 $ python3 -m hstrat._auxiliary_lib._alifestd_prune_extinct_lineages_polars
 $ python3 -m hstrat._auxiliary_lib._alifestd_test_leaves_isomorphic_asexual

--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -96,13 +96,13 @@ from ._alifestd_delete_trunk_asexual_polars import (
 from ._alifestd_delete_unifurcating_roots_asexual import (
     alifestd_delete_unifurcating_roots_asexual,
 )
+from ._alifestd_downsample_tips_asexual import alifestd_downsample_tips_asexual
 from ._alifestd_downsample_tips_canopy_asexual import (
     alifestd_downsample_tips_canopy_asexual,
 )
 from ._alifestd_downsample_tips_canopy_polars import (
     alifestd_downsample_tips_canopy_polars,
 )
-from ._alifestd_downsample_tips_asexual import alifestd_downsample_tips_asexual
 from ._alifestd_downsample_tips_clade_asexual import (
     alifestd_downsample_tips_clade_asexual,
 )

--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -96,11 +96,11 @@ from ._alifestd_delete_trunk_asexual_polars import (
 from ._alifestd_delete_unifurcating_roots_asexual import (
     alifestd_delete_unifurcating_roots_asexual,
 )
-from ._alifestd_downsample_canopy_asexual import (
-    alifestd_downsample_canopy_asexual,
+from ._alifestd_downsample_tips_canopy_asexual import (
+    alifestd_downsample_tips_canopy_asexual,
 )
-from ._alifestd_downsample_canopy_polars import (
-    alifestd_downsample_canopy_polars,
+from ._alifestd_downsample_tips_canopy_polars import (
+    alifestd_downsample_tips_canopy_polars,
 )
 from ._alifestd_downsample_tips_asexual import alifestd_downsample_tips_asexual
 from ._alifestd_downsample_tips_clade_asexual import (
@@ -498,8 +498,8 @@ __all__ = [
     "alifestd_delete_trunk_asexual",
     "alifestd_delete_trunk_asexual_polars",
     "alifestd_delete_unifurcating_roots_asexual",
-    "alifestd_downsample_canopy_asexual",
-    "alifestd_downsample_canopy_polars",
+    "alifestd_downsample_tips_canopy_asexual",
+    "alifestd_downsample_tips_canopy_polars",
     "alifestd_downsample_tips_asexual",
     "alifestd_downsample_tips_clade_asexual",
     "alifestd_downsample_tips_polars",

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_canopy_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_canopy_asexual.py
@@ -31,7 +31,7 @@ from ._log_context_duration import log_context_duration
     delete=True,
     update=False,
 )
-def alifestd_downsample_canopy_asexual(
+def alifestd_downsample_tips_canopy_asexual(
     phylogeny_df: pd.DataFrame,
     num_tips: int,
     mutate: bool = False,
@@ -81,7 +81,7 @@ def alifestd_downsample_canopy_asexual(
     phylogeny_df = alifestd_try_add_ancestor_id_col(phylogeny_df)
     if "ancestor_id" not in phylogeny_df.columns:
         raise ValueError(
-            "alifestd_downsample_canopy_asexual only supports "
+            "alifestd_downsample_tips_canopy_asexual only supports "
             "asexual phylogenies.",
         )
 
@@ -128,7 +128,7 @@ Otherwise, no action is taken.
 
 See Also
 ========
-hstrat._auxiliary_lib._alifestd_downsample_canopy_polars :
+hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars :
     Entrypoint for high-performance Polars-based implementation.
 """
 
@@ -141,7 +141,7 @@ def _create_parser() -> argparse.ArgumentParser:
     )
     parser = _add_parser_base(
         parser=parser,
-        dfcli_module="hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual",
+        dfcli_module="hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual",
         dfcli_version=get_hstrat_version(),
     )
     parser.add_argument(
@@ -177,14 +177,14 @@ if __name__ == "__main__":
     parser = _create_parser()
     args, __ = parser.parse_known_args()
     with log_context_duration(
-        "hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual",
+        "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual",
         logging.info,
     ):
         _run_dataframe_cli(
             base_parser=parser,
             output_dataframe_op=delegate_polars_implementation()(
                 functools.partial(
-                    alifestd_downsample_canopy_asexual,
+                    alifestd_downsample_tips_canopy_asexual,
                     num_tips=args.n,
                     criterion=args.criterion,
                     ignore_topological_sensitivity=args.ignore_topological_sensitivity,

--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_canopy_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_canopy_polars.py
@@ -27,7 +27,7 @@ from ._log_context_duration import log_context_duration
     delete=True,
     update=False,
 )
-def alifestd_downsample_canopy_polars(
+def alifestd_downsample_tips_canopy_polars(
     phylogeny_df: pl.DataFrame,
     num_tips: int,
     criterion: str = "origin_time",
@@ -67,7 +67,7 @@ def alifestd_downsample_canopy_polars(
 
     See Also
     --------
-    alifestd_downsample_canopy_asexual :
+    alifestd_downsample_tips_canopy_asexual :
         Pandas-based implementation.
     """
     schema_names = phylogeny_df.lazy().collect_schema().names()
@@ -83,12 +83,12 @@ def alifestd_downsample_canopy_polars(
         return phylogeny_df
 
     logging.info(
-        "- alifestd_downsample_canopy_polars: finding leaf ids...",
+        "- alifestd_downsample_tips_canopy_polars: finding leaf ids...",
     )
     marked_df = alifestd_mark_leaves_polars(phylogeny_df)
 
     logging.info(
-        "- alifestd_downsample_canopy_polars: selecting top leaf_ids...",
+        "- alifestd_downsample_tips_canopy_polars: selecting top leaf_ids...",
     )
     leaf_ids = (
         marked_df.lazy()
@@ -101,14 +101,14 @@ def alifestd_downsample_canopy_polars(
     )
 
     logging.info(
-        "- alifestd_downsample_canopy_polars: marking extant...",
+        "- alifestd_downsample_tips_canopy_polars: marking extant...",
     )
     phylogeny_df = phylogeny_df.with_columns(
         extant=pl.col("id").is_in(leaf_ids),
     )
 
     logging.info(
-        "- alifestd_downsample_canopy_polars: pruning...",
+        "- alifestd_downsample_tips_canopy_polars: pruning...",
     )
     return alifestd_prune_extinct_lineages_polars(phylogeny_df).drop("extant")
 
@@ -133,7 +133,7 @@ Otherwise, no action is taken.
 
 See Also
 ========
-hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual :
+hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual :
     CLI entrypoint for Pandas-based implementation.
 """
 
@@ -146,7 +146,7 @@ def _create_parser() -> argparse.ArgumentParser:
     )
     parser = _add_parser_base(
         parser=parser,
-        dfcli_module="hstrat._auxiliary_lib._alifestd_downsample_canopy_polars",
+        dfcli_module="hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars",
         dfcli_version=get_hstrat_version(),
     )
     parser.add_argument(
@@ -184,13 +184,13 @@ if __name__ == "__main__":
 
     try:
         with log_context_duration(
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_polars",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars",
             logging.info,
         ):
             _run_dataframe_cli(
                 base_parser=parser,
                 output_dataframe_op=functools.partial(
-                    alifestd_downsample_canopy_polars,
+                    alifestd_downsample_tips_canopy_polars,
                     num_tips=args.n,
                     criterion=args.criterion,
                     ignore_topological_sensitivity=args.ignore_topological_sensitivity,

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_asexual.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_asexual.py
@@ -12,8 +12,8 @@ from hstrat._auxiliary_lib import (
     alifestd_try_add_ancestor_id_col,
     alifestd_validate,
 )
-from hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual import (
-    alifestd_downsample_canopy_asexual,
+from hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual import (
+    alifestd_downsample_tips_canopy_asexual,
 )
 
 assets_path = os.path.join(os.path.dirname(__file__), "assets")
@@ -35,10 +35,10 @@ assets_path = os.path.join(os.path.dirname(__file__), "assets")
 )
 @pytest.mark.parametrize("num_tips", [1, 5, 10, 100000000])
 @pytest.mark.parametrize("mutate", [True, False])
-def test_alifestd_downsample_canopy_asexual(phylogeny_df, num_tips, mutate):
+def test_alifestd_downsample_tips_canopy_asexual(phylogeny_df, num_tips, mutate):
     original_df = phylogeny_df.copy()
 
-    result_df = alifestd_downsample_canopy_asexual(
+    result_df = alifestd_downsample_tips_canopy_asexual(
         phylogeny_df, num_tips, mutate, criterion="id"
     )
 
@@ -55,10 +55,10 @@ def test_alifestd_downsample_canopy_asexual(phylogeny_df, num_tips, mutate):
 
 
 @pytest.mark.parametrize("num_tips", [0, 1])
-def test_alifestd_downsample_canopy_asexual_with_zero_tips(num_tips):
+def test_alifestd_downsample_tips_canopy_asexual_with_zero_tips(num_tips):
     phylogeny_df = pd.DataFrame({"id": [], "parent_id": [], "ancestor_id": []})
 
-    result_df = alifestd_downsample_canopy_asexual(
+    result_df = alifestd_downsample_tips_canopy_asexual(
         phylogeny_df, num_tips, criterion="id"
     )
 
@@ -84,7 +84,7 @@ def test_downsample_canopy_vs_manual(phylogeny_df, num_tips):
     """Verify canopy prune matches manually marking top tips as extant and
     then pruning extinct lineages."""
     original_df = phylogeny_df.copy()
-    canopy_df = alifestd_downsample_canopy_asexual(
+    canopy_df = alifestd_downsample_tips_canopy_asexual(
         phylogeny_df, num_tips, mutate=False, criterion="id"
     )
 
@@ -110,10 +110,10 @@ def test_downsample_canopy_vs_manual(phylogeny_df, num_tips):
         pd.read_csv(f"{assets_path}/nk_tournamentselection.csv"),
     ],
 )
-def test_alifestd_downsample_canopy_asexual_retains_highest_ids(phylogeny_df):
+def test_alifestd_downsample_tips_canopy_asexual_retains_highest_ids(phylogeny_df):
     """Verify that the retained tips are the ones with the highest ids."""
     num_tips = 5
-    result_df = alifestd_downsample_canopy_asexual(
+    result_df = alifestd_downsample_tips_canopy_asexual(
         phylogeny_df, num_tips, criterion="id"
     )
 
@@ -132,15 +132,15 @@ def test_alifestd_downsample_canopy_asexual_retains_highest_ids(phylogeny_df):
         pd.read_csv(f"{assets_path}/nk_tournamentselection.csv"),
     ],
 )
-def test_alifestd_downsample_canopy_asexual_validates(phylogeny_df):
+def test_alifestd_downsample_tips_canopy_asexual_validates(phylogeny_df):
     num_tips = 5
-    result_df = alifestd_downsample_canopy_asexual(
+    result_df = alifestd_downsample_tips_canopy_asexual(
         phylogeny_df, num_tips, criterion="id"
     )
     assert alifestd_validate(result_df)
 
 
-def test_alifestd_downsample_canopy_asexual_simple():
+def test_alifestd_downsample_tips_canopy_asexual_simple():
     """Test a simple hand-crafted tree.
 
     Tree structure:
@@ -160,14 +160,14 @@ def test_alifestd_downsample_canopy_asexual_simple():
         }
     )
 
-    result2 = alifestd_downsample_canopy_asexual(df, 2, criterion="id")
+    result2 = alifestd_downsample_tips_canopy_asexual(df, 2, criterion="id")
     assert set(result2["id"]) == {0, 1, 3, 4}
 
-    result1 = alifestd_downsample_canopy_asexual(df, 1, criterion="id")
+    result1 = alifestd_downsample_tips_canopy_asexual(df, 1, criterion="id")
     assert set(result1["id"]) == {0, 1, 4}
 
 
-def test_alifestd_downsample_canopy_asexual_all_tips():
+def test_alifestd_downsample_tips_canopy_asexual_all_tips():
     """Requesting more tips than exist should return the full phylogeny."""
     df = pd.DataFrame(
         {
@@ -176,11 +176,11 @@ def test_alifestd_downsample_canopy_asexual_all_tips():
         }
     )
 
-    result = alifestd_downsample_canopy_asexual(df, 100000, criterion="id")
+    result = alifestd_downsample_tips_canopy_asexual(df, 100000, criterion="id")
     assert len(result) == 5
 
 
-def test_alifestd_downsample_canopy_asexual_tied_criterion():
+def test_alifestd_downsample_tips_canopy_asexual_tied_criterion():
     """When all leaves share the same criterion value, exactly num_tips
     should still be retained (ties broken arbitrarily)."""
     df = pd.DataFrame(
@@ -192,13 +192,13 @@ def test_alifestd_downsample_canopy_asexual_tied_criterion():
     )
     # leaves are 2, 3, 4 — all have time=0
     for num_tips in (1, 2, 3):
-        result = alifestd_downsample_canopy_asexual(
+        result = alifestd_downsample_tips_canopy_asexual(
             df, num_tips, criterion="time"
         )
         assert alifestd_count_leaf_nodes(result) == num_tips
 
 
-def test_alifestd_downsample_canopy_asexual_missing_criterion():
+def test_alifestd_downsample_tips_canopy_asexual_missing_criterion():
     """Verify ValueError when criterion column is missing."""
     df = pd.DataFrame(
         {
@@ -208,4 +208,4 @@ def test_alifestd_downsample_canopy_asexual_missing_criterion():
     )
 
     with pytest.raises(ValueError, match="criterion column"):
-        alifestd_downsample_canopy_asexual(df, 1, criterion="nonexistent")
+        alifestd_downsample_tips_canopy_asexual(df, 1, criterion="nonexistent")

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_asexual.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_asexual.py
@@ -35,7 +35,9 @@ assets_path = os.path.join(os.path.dirname(__file__), "assets")
 )
 @pytest.mark.parametrize("num_tips", [1, 5, 10, 100000000])
 @pytest.mark.parametrize("mutate", [True, False])
-def test_alifestd_downsample_tips_canopy_asexual(phylogeny_df, num_tips, mutate):
+def test_alifestd_downsample_tips_canopy_asexual(
+    phylogeny_df, num_tips, mutate
+):
     original_df = phylogeny_df.copy()
 
     result_df = alifestd_downsample_tips_canopy_asexual(
@@ -110,7 +112,9 @@ def test_downsample_canopy_vs_manual(phylogeny_df, num_tips):
         pd.read_csv(f"{assets_path}/nk_tournamentselection.csv"),
     ],
 )
-def test_alifestd_downsample_tips_canopy_asexual_retains_highest_ids(phylogeny_df):
+def test_alifestd_downsample_tips_canopy_asexual_retains_highest_ids(
+    phylogeny_df,
+):
     """Verify that the retained tips are the ones with the highest ids."""
     num_tips = 5
     result_df = alifestd_downsample_tips_canopy_asexual(
@@ -176,7 +180,9 @@ def test_alifestd_downsample_tips_canopy_asexual_all_tips():
         }
     )
 
-    result = alifestd_downsample_tips_canopy_asexual(df, 100000, criterion="id")
+    result = alifestd_downsample_tips_canopy_asexual(
+        df, 100000, criterion="id"
+    )
     assert len(result) == 5
 
 

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_asexual_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_asexual_cli.py
@@ -5,39 +5,39 @@ import subprocess
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
 
 
-def test_alifestd_downsample_canopy_asexual_cli_help():
+def test_alifestd_downsample_tips_canopy_asexual_cli_help():
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual",
             "--help",
         ],
         check=True,
     )
 
 
-def test_alifestd_downsample_canopy_asexual_cli_version():
+def test_alifestd_downsample_tips_canopy_asexual_cli_version():
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual",
             "--version",
         ],
         check=True,
     )
 
 
-def test_alifestd_downsample_canopy_asexual_cli_csv(tmp_path):
+def test_alifestd_downsample_tips_canopy_asexual_cli_csv(tmp_path):
     output_file = str(
-        tmp_path / "hstrat_alifestd_downsample_canopy_asexual.csv"
+        tmp_path / "hstrat_alifestd_downsample_tips_canopy_asexual.csv"
     )
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual",
             "-n",
             "1",
             "--criterion",
@@ -50,15 +50,15 @@ def test_alifestd_downsample_canopy_asexual_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_downsample_canopy_asexual_cli_parquet(tmp_path):
+def test_alifestd_downsample_tips_canopy_asexual_cli_parquet(tmp_path):
     output_file = str(
-        tmp_path / "hstrat_alifestd_downsample_canopy_asexual.pqt"
+        tmp_path / "hstrat_alifestd_downsample_tips_canopy_asexual.pqt"
     )
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual",
             "-n",
             "1",
             "--criterion",
@@ -71,14 +71,14 @@ def test_alifestd_downsample_canopy_asexual_cli_parquet(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_downsample_canopy_asexual_cli_ignore_topological_sensitivity():  # noqa: E501
-    output_file = "/tmp/hstrat_alifestd_downsample_canopy_asexual_ignore.csv"  # nosec B108
+def test_alifestd_downsample_tips_canopy_asexual_cli_ignore_topological_sensitivity():  # noqa: E501
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_canopy_asexual_ignore.csv"  # nosec B108
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual",
             "-n",
             "1",
             "--criterion",
@@ -92,16 +92,16 @@ def test_alifestd_downsample_canopy_asexual_cli_ignore_topological_sensitivity()
     assert os.path.exists(output_file)
 
 
-def test_alifestd_downsample_canopy_asexual_cli_drop_topological_sensitivity():
+def test_alifestd_downsample_tips_canopy_asexual_cli_drop_topological_sensitivity():
     output_file = (
-        "/tmp/hstrat_alifestd_downsample_canopy_asexual_drop.csv"  # nosec B108
+        "/tmp/hstrat_alifestd_downsample_tips_canopy_asexual_drop.csv"  # nosec B108
     )
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual",
             "-n",
             "1",
             "--criterion",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_asexual_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_asexual_cli.py
@@ -93,9 +93,7 @@ def test_alifestd_downsample_tips_canopy_asexual_cli_ignore_topological_sensitiv
 
 
 def test_alifestd_downsample_tips_canopy_asexual_cli_drop_topological_sensitivity():
-    output_file = (
-        "/tmp/hstrat_alifestd_downsample_tips_canopy_asexual_drop.csv"  # nosec B108
-    )
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_canopy_asexual_drop.csv"  # nosec B108
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_polars.py
@@ -9,11 +9,11 @@ from hstrat._auxiliary_lib import (
     alifestd_find_leaf_ids,
     alifestd_to_working_format,
 )
-from hstrat._auxiliary_lib._alifestd_downsample_canopy_asexual import (
-    alifestd_downsample_canopy_asexual,
+from hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_asexual import (
+    alifestd_downsample_tips_canopy_asexual,
 )
-from hstrat._auxiliary_lib._alifestd_downsample_canopy_polars import (
-    alifestd_downsample_canopy_polars,
+from hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars import (
+    alifestd_downsample_tips_canopy_polars,
 )
 
 assets_path = os.path.join(os.path.dirname(__file__), "assets")
@@ -54,7 +54,7 @@ def _count_leaf_nodes_polars(phylogeny_df: pl.DataFrame) -> int:
     ],
 )
 @pytest.mark.parametrize("num_tips", [1, 5, 10, 100000000])
-def test_alifestd_downsample_canopy_polars(
+def test_alifestd_downsample_tips_canopy_polars(
     phylogeny_df: pd.DataFrame,
     num_tips: int,
 ):
@@ -63,7 +63,7 @@ def test_alifestd_downsample_canopy_polars(
     original_len = len(phylogeny_df_pl)
     original_num_tips = _count_leaf_nodes_polars(phylogeny_df_pl)
 
-    result_df = alifestd_downsample_canopy_polars(
+    result_df = alifestd_downsample_tips_canopy_polars(
         phylogeny_df_pl,
         num_tips,
         criterion="id",
@@ -80,13 +80,13 @@ def test_alifestd_downsample_canopy_polars(
 
 
 @pytest.mark.parametrize("num_tips", [0, 1])
-def test_alifestd_downsample_canopy_polars_empty(num_tips: int):
+def test_alifestd_downsample_tips_canopy_polars_empty(num_tips: int):
     phylogeny_df = pl.DataFrame(
         {"id": [], "ancestor_id": []},
         schema={"id": pl.Int64, "ancestor_id": pl.Int64},
     )
 
-    result_df = alifestd_downsample_canopy_polars(
+    result_df = alifestd_downsample_tips_canopy_polars(
         phylogeny_df, num_tips, criterion="id"
     )
 
@@ -116,17 +116,17 @@ def test_alifestd_downsample_canopy_polars_empty(num_tips: int):
     ],
 )
 @pytest.mark.parametrize("num_tips", [1, 5, 10])
-def test_alifestd_downsample_canopy_polars_matches_pandas(
+def test_alifestd_downsample_tips_canopy_polars_matches_pandas(
     phylogeny_df: pd.DataFrame,
     num_tips: int,
 ):
     """Verify polars result matches pandas result for same prepared input."""
     phylogeny_df_pl = pl.from_pandas(phylogeny_df)
 
-    result_pd = alifestd_downsample_canopy_asexual(
+    result_pd = alifestd_downsample_tips_canopy_asexual(
         phylogeny_df, num_tips, mutate=False, criterion="id"
     )
-    result_pl = alifestd_downsample_canopy_polars(
+    result_pl = alifestd_downsample_tips_canopy_polars(
         phylogeny_df_pl, num_tips, criterion="id"
     )
 
@@ -148,13 +148,13 @@ def test_alifestd_downsample_canopy_polars_matches_pandas(
         ),
     ],
 )
-def test_alifestd_downsample_canopy_polars_retains_highest_ids(
+def test_alifestd_downsample_tips_canopy_polars_retains_highest_ids(
     phylogeny_df: pd.DataFrame,
 ):
     """Verify that the retained tips are the ones with the highest ids."""
     num_tips = 5
     phylogeny_df_pl = pl.from_pandas(phylogeny_df)
-    result_df = alifestd_downsample_canopy_polars(
+    result_df = alifestd_downsample_tips_canopy_polars(
         phylogeny_df_pl, num_tips, criterion="id"
     )
 
@@ -173,7 +173,7 @@ def test_alifestd_downsample_canopy_polars_retains_highest_ids(
     assert result_tips == expected_kept
 
 
-def test_alifestd_downsample_canopy_polars_no_ancestor_id():
+def test_alifestd_downsample_tips_canopy_polars_no_ancestor_id():
     df = pl.DataFrame(
         {
             "id": [0, 1, 2],
@@ -181,10 +181,10 @@ def test_alifestd_downsample_canopy_polars_no_ancestor_id():
         }
     )
     with pytest.raises(NotImplementedError):
-        alifestd_downsample_canopy_polars(df, 1, criterion="id")
+        alifestd_downsample_tips_canopy_polars(df, 1, criterion="id")
 
 
-def test_alifestd_downsample_canopy_polars_simple():
+def test_alifestd_downsample_tips_canopy_polars_simple():
     """Test a simple hand-crafted tree.
 
     Tree structure:
@@ -205,14 +205,14 @@ def test_alifestd_downsample_canopy_polars_simple():
         }
     )
 
-    result2 = alifestd_downsample_canopy_polars(df, 2, criterion="id")
+    result2 = alifestd_downsample_tips_canopy_polars(df, 2, criterion="id")
     assert set(result2["id"].to_list()) == {0, 1, 3, 4}
 
-    result1 = alifestd_downsample_canopy_polars(df, 1, criterion="id")
+    result1 = alifestd_downsample_tips_canopy_polars(df, 1, criterion="id")
     assert set(result1["id"].to_list()) == {0, 1, 4}
 
 
-def test_alifestd_downsample_canopy_polars_all_tips():
+def test_alifestd_downsample_tips_canopy_polars_all_tips():
     """Requesting more tips than exist should return the full phylogeny."""
     df = pl.DataFrame(
         {
@@ -222,12 +222,12 @@ def test_alifestd_downsample_canopy_polars_all_tips():
         }
     )
 
-    result = alifestd_downsample_canopy_polars(df, 100000, criterion="id")
+    result = alifestd_downsample_tips_canopy_polars(df, 100000, criterion="id")
 
     assert len(result) == 5
 
 
-def test_alifestd_downsample_canopy_polars_tied_criterion():
+def test_alifestd_downsample_tips_canopy_polars_tied_criterion():
     """When all leaves share the same criterion value, exactly num_tips
     should still be retained (ties broken arbitrarily)."""
     df = pl.DataFrame(
@@ -240,13 +240,13 @@ def test_alifestd_downsample_canopy_polars_tied_criterion():
     )
     # leaves are 2, 3, 4 — all have time=0
     for num_tips in (1, 2, 3):
-        result = alifestd_downsample_canopy_polars(
+        result = alifestd_downsample_tips_canopy_polars(
             df, num_tips, criterion="time"
         )
         assert _count_leaf_nodes_polars(result) == num_tips
 
 
-def test_alifestd_downsample_canopy_polars_missing_criterion():
+def test_alifestd_downsample_tips_canopy_polars_missing_criterion():
     """Verify ValueError when criterion column is missing."""
     df = pl.DataFrame(
         {
@@ -256,4 +256,4 @@ def test_alifestd_downsample_canopy_polars_missing_criterion():
     )
 
     with pytest.raises(ValueError, match="criterion column"):
-        alifestd_downsample_canopy_polars(df, 1, criterion="nonexistent")
+        alifestd_downsample_tips_canopy_polars(df, 1, criterion="nonexistent")

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_polars_cli.py
@@ -5,39 +5,39 @@ import subprocess
 assets = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
 
 
-def test_alifestd_downsample_canopy_polars_cli_help():
+def test_alifestd_downsample_tips_canopy_polars_cli_help():
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_polars",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars",
             "--help",
         ],
         check=True,
     )
 
 
-def test_alifestd_downsample_canopy_polars_cli_version():
+def test_alifestd_downsample_tips_canopy_polars_cli_version():
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_polars",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars",
             "--version",
         ],
         check=True,
     )
 
 
-def test_alifestd_downsample_canopy_polars_cli_csv(tmp_path):
+def test_alifestd_downsample_tips_canopy_polars_cli_csv(tmp_path):
     output_file = str(
-        tmp_path / "hstrat_alifestd_downsample_canopy_polars.csv"
+        tmp_path / "hstrat_alifestd_downsample_tips_canopy_polars.csv"
     )
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_polars",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars",
             "-n",
             "4",
             "--criterion",
@@ -51,15 +51,15 @@ def test_alifestd_downsample_canopy_polars_cli_csv(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_downsample_canopy_polars_cli_empty(tmp_path):
+def test_alifestd_downsample_tips_canopy_polars_cli_empty(tmp_path):
     output_file = str(
-        tmp_path / "hstrat_alifestd_downsample_canopy_polars.csv"
+        tmp_path / "hstrat_alifestd_downsample_tips_canopy_polars.csv"
     )
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_polars",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars",
             "-n",
             "10",
             "--criterion",
@@ -72,14 +72,14 @@ def test_alifestd_downsample_canopy_polars_cli_empty(tmp_path):
     assert os.path.exists(output_file)
 
 
-def test_alifestd_downsample_canopy_polars_cli_ignore_topological_sensitivity():  # noqa: E501
-    output_file = "/tmp/hstrat_alifestd_downsample_canopy_polars_ignore.csv"  # nosec B108
+def test_alifestd_downsample_tips_canopy_polars_cli_ignore_topological_sensitivity():  # noqa: E501
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_canopy_polars_ignore.csv"  # nosec B108
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_polars",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars",
             "-n",
             "4",
             "--criterion",
@@ -94,16 +94,16 @@ def test_alifestd_downsample_canopy_polars_cli_ignore_topological_sensitivity():
     assert os.path.exists(output_file)
 
 
-def test_alifestd_downsample_canopy_polars_cli_drop_topological_sensitivity():
+def test_alifestd_downsample_tips_canopy_polars_cli_drop_topological_sensitivity():
     output_file = (
-        "/tmp/hstrat_alifestd_downsample_canopy_polars_drop.csv"  # nosec B108
+        "/tmp/hstrat_alifestd_downsample_tips_canopy_polars_drop.csv"  # nosec B108
     )
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [
             "python3",
             "-m",
-            "hstrat._auxiliary_lib._alifestd_downsample_canopy_polars",
+            "hstrat._auxiliary_lib._alifestd_downsample_tips_canopy_polars",
             "-n",
             "4",
             "--criterion",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_polars_cli.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_downsample_tips_canopy_polars_cli.py
@@ -95,9 +95,7 @@ def test_alifestd_downsample_tips_canopy_polars_cli_ignore_topological_sensitivi
 
 
 def test_alifestd_downsample_tips_canopy_polars_cli_drop_topological_sensitivity():
-    output_file = (
-        "/tmp/hstrat_alifestd_downsample_tips_canopy_polars_drop.csv"  # nosec B108
-    )
+    output_file = "/tmp/hstrat_alifestd_downsample_tips_canopy_polars_drop.csv"  # nosec B108
     pathlib.Path(output_file).unlink(missing_ok=True)
     subprocess.run(  # nosec B603
         [


### PR DESCRIPTION
## Summary
Rename the `alifestd_downsample_canopy_asexual` and `alifestd_downsample_canopy_polars` functions to `alifestd_downsample_tips_canopy_asexual` and `alifestd_downsample_tips_canopy_polars` respectively to better reflect their functionality of downsampling tips (leaf nodes) in a phylogenetic canopy.

## Key Changes
- Renamed function `alifestd_downsample_canopy_asexual` → `alifestd_downsample_tips_canopy_asexual` in `_alifestd_downsample_tips_canopy_asexual.py`
- Renamed function `alifestd_downsample_canopy_polars` → `alifestd_downsample_tips_canopy_polars` in `_alifestd_downsample_tips_canopy_polars.py`
- Updated all test files to use the new function names:
  - `test_alifestd_downsample_tips_canopy_asexual.py`
  - `test_alifestd_downsample_tips_canopy_polars.py`
  - `test_alifestd_downsample_tips_canopy_asexual_cli.py`
  - `test_alifestd_downsample_tips_canopy_polars_cli.py`
- Updated module imports in `__init__.pyi` to export the renamed functions
- Updated CLI module references and logging messages to use new function names
- Updated documentation references in `__main__.py`

## Implementation Details
- All function signatures remain unchanged; only the function names were updated
- All internal references, logging messages, and docstring cross-references were updated to use the new names
- CLI entrypoints and module paths were updated to reflect the new naming convention
- The functionality and behavior of the functions remain identical

https://claude.ai/code/session_01UZHad2A4Qeo16TwnBeJ7n8