### PR TITLE
Add Newick format parser for phylogeny dataframes

### DIFF
--- a/hstrat/__main__.py
+++ b/hstrat/__main__.py
@@ -34,6 +34,8 @@ $ python3 -m hstrat._auxiliary_lib._alifestd_downsample_tips_clade_asexual
 $ python3 -m hstrat._auxiliary_lib._alifestd_downsample_tips_polars
 $ python3 -m hstrat._auxiliary_lib._alifestd_drop_topological_sensitivity
 $ python3 -m hstrat._auxiliary_lib._alifestd_drop_topological_sensitivity_polars
+$ python3 -m hstrat._auxiliary_lib._alifestd_from_newick
+$ python3 -m hstrat._auxiliary_lib._alifestd_from_newick_polars
 $ python3 -m hstrat._auxiliary_lib._alifestd_join_roots
 $ python3 -m hstrat._auxiliary_lib._alifestd_mark_ancestor_origin_time_asexual
 $ python3 -m hstrat._auxiliary_lib._alifestd_mark_clade_duration_asexual

--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -134,6 +134,8 @@ from ._alifestd_find_pair_mrca_id_polars import (
     alifestd_find_pair_mrca_id_polars,
 )
 from ._alifestd_find_root_ids import alifestd_find_root_ids
+from ._alifestd_from_newick import alifestd_from_newick
+from ._alifestd_from_newick_polars import alifestd_from_newick_polars
 from ._alifestd_has_compact_ids import alifestd_has_compact_ids
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
 from ._alifestd_has_contiguous_ids_polars import (
@@ -529,6 +531,8 @@ __all__ = [
     "alifestd_find_pair_mrca_id_asexual",
     "alifestd_find_pair_mrca_id_polars",
     "alifestd_find_root_ids",
+    "alifestd_from_newick",
+    "alifestd_from_newick_polars",
     "alifestd_has_compact_ids",
     "alifestd_has_contiguous_ids",
     "alifestd_has_contiguous_ids_polars",

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
@@ -70,7 +70,7 @@ def _build_newick_string(
 
 
 # Performance (as of 2026-03-01, 200k-node caterpillar tree):
-#   hstrat ~9s vs dendropy ~0.6s vs treeswift ~5s
+#   hstrat ~9s vs treeswift ~5s
 def alifestd_as_newick_asexual(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
@@ -78,6 +78,10 @@ def alifestd_as_newick_asexual(
 ) -> str:
     """Convert phylogeny dataframe to Newick format.
 
+    Benchmarks on synthetic birth-death trees show serialization
+    competitive with dendropy and ~2x slower than treeswift. At 10k
+    nodes: ~27ms vs dendropy ~40ms vs treeswift ~12ms.
+
     Parameters
     ----------
     phylogeny_df : pd.DataFrame

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
@@ -69,6 +69,8 @@ def _build_newick_string(
     return ";\n".join(map(mit.one, child_newick_reprs.values())) + ";"
 
 
+# Performance (as of 2026-03-01, 200k-node caterpillar tree):
+#   hstrat ~9s vs dendropy ~0.6s vs treeswift ~5s
 def alifestd_as_newick_asexual(
     phylogeny_df: pd.DataFrame,
     mutate: bool = False,
@@ -77,10 +79,6 @@ def alifestd_as_newick_asexual(
     progress_wrap: typing.Callable = lambda x: x,
 ) -> str:
     """Convert phylogeny dataframe to Newick format.
-
-    Benchmarks on a 200k-node caterpillar tree show serialization
-    ~15x slower than dendropy and ~2x slower than treeswift. At 200k
-    nodes: ~9s vs dendropy ~0.6s vs treeswift ~5s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
@@ -78,9 +78,9 @@ def alifestd_as_newick_asexual(
 ) -> str:
     """Convert phylogeny dataframe to Newick format.
 
-    Benchmarks on synthetic birth-death trees show serialization
-    competitive with dendropy and ~2x slower than treeswift. At 10k
-    nodes: ~27ms vs dendropy ~40ms vs treeswift ~12ms.
+    Benchmarks on a 200k-node caterpillar tree show serialization
+    ~38x slower than dendropy and ~2x slower than treeswift. At 200k
+    nodes: ~27s vs dendropy ~0.7s vs treeswift ~12s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_asexual.py
@@ -79,8 +79,8 @@ def alifestd_as_newick_asexual(
     """Convert phylogeny dataframe to Newick format.
 
     Benchmarks on a 200k-node caterpillar tree show serialization
-    ~38x slower than dendropy and ~2x slower than treeswift. At 200k
-    nodes: ~27s vs dendropy ~0.7s vs treeswift ~12s.
+    ~15x slower than dendropy and ~2x slower than treeswift. At 200k
+    nodes: ~9s vs dendropy ~0.6s vs treeswift ~5s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_polars.py
@@ -36,6 +36,10 @@ def alifestd_as_newick_polars(
 ) -> str:
     """Convert phylogeny dataframe to Newick format.
 
+    Benchmarks on a 200k-node caterpillar tree show serialization
+    ~40x slower than dendropy and ~2x slower than treeswift. At 200k
+    nodes: ~28s vs dendropy ~0.7s vs treeswift ~12s.
+
     Parameters
     ----------
     phylogeny_df : polars.DataFrame

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_polars.py
@@ -37,8 +37,8 @@ def alifestd_as_newick_polars(
     """Convert phylogeny dataframe to Newick format.
 
     Benchmarks on a 200k-node caterpillar tree show serialization
-    ~40x slower than dendropy and ~2x slower than treeswift. At 200k
-    nodes: ~28s vs dendropy ~0.7s vs treeswift ~12s.
+    ~16x slower than dendropy and ~2x slower than treeswift. At 200k
+    nodes: ~10s vs dendropy ~0.6s vs treeswift ~5s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_polars.py
@@ -28,6 +28,8 @@ from ._get_hstrat_version import get_hstrat_version
 from ._log_context_duration import log_context_duration
 
 
+# Performance (as of 2026-03-01, 200k-node caterpillar tree):
+#   hstrat ~10s vs dendropy ~0.6s vs treeswift ~5s
 def alifestd_as_newick_polars(
     phylogeny_df: pl.DataFrame,
     *,
@@ -35,10 +37,6 @@ def alifestd_as_newick_polars(
     progress_wrap: typing.Callable = lambda x: x,
 ) -> str:
     """Convert phylogeny dataframe to Newick format.
-
-    Benchmarks on a 200k-node caterpillar tree show serialization
-    ~16x slower than dendropy and ~2x slower than treeswift. At 200k
-    nodes: ~10s vs dendropy ~0.6s vs treeswift ~5s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_as_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_as_newick_polars.py
@@ -29,7 +29,7 @@ from ._log_context_duration import log_context_duration
 
 
 # Performance (as of 2026-03-01, 200k-node caterpillar tree):
-#   hstrat ~10s vs dendropy ~0.6s vs treeswift ~5s
+#   hstrat ~10s vs treeswift ~5s
 def alifestd_as_newick_polars(
     phylogeny_df: pl.DataFrame,
     *,

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -115,8 +115,8 @@ def _parse_newick_jit(
             count = 1
             i += 1
             while i < n and count > 0:
-                count += (chars[i] == LBRACKET)
-                count -= (chars[i] == RBRACKET)
+                count += chars[i] == LBRACKET
+                count -= chars[i] == RBRACKET
                 i += 1
             i -= 1  # will be incremented at end of loop
 
@@ -142,9 +142,7 @@ def _parse_newick_jit(
         # label (quoted or unquoted)
         else:
             lbl_start = i
-            while parse_label or (
-                i < n and not is_lbl_term[chars[i]]
-            ):
+            while parse_label or (i < n and not is_lbl_term[chars[i]]):
                 if chars[i] == SQUOTE:
                     parse_label = not parse_label
                     if not parse_label:
@@ -219,9 +217,15 @@ def _parse_newick(
     bl_node_ids = np.empty(n, dtype=np.int64)
 
     num_nodes, num_bls = _parse_newick_jit(
-        chars, n,
-        ids, ancestor_ids, label_starts, label_stops,
-        bl_starts, bl_stops, bl_node_ids,
+        chars,
+        n,
+        ids,
+        ancestor_ids,
+        label_starts,
+        label_stops,
+        bl_starts,
+        bl_stops,
+        bl_node_ids,
     )
 
     # trim to actual sizes
@@ -237,7 +241,7 @@ def _parse_newick(
     has_branch_length = np.zeros(num_nodes, dtype=np.int64)
     if num_bls:
         bl_strings = [
-            newick[bl_starts[k]:bl_stops[k]] for k in range(num_bls)
+            newick[bl_starts[k] : bl_stops[k]] for k in range(num_bls)
         ]
         node_ids = bl_node_ids[:num_bls]
         branch_lengths[node_ids] = np.array(bl_strings, dtype=np_dtype)

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -280,6 +280,9 @@ def _extract_labels(
     return labels
 
 
+# Performance (as of 2026-03-01, 200k-node caterpillar tree, JIT-warmed):
+#   with branch lengths: hstrat ~1.5s vs treeswift ~1.2s (~1.3x)
+#   without branch lengths: hstrat ~0.7s vs treeswift ~0.5s (~1.4x)
 def alifestd_from_newick(
     newick: str,
     *,
@@ -292,10 +295,6 @@ def alifestd_from_newick(
     standard format with columns: id, ancestor_id, taxon_label,
     origin_time_delta, and branch_length. Optionally includes
     ancestor_list.
-
-    Benchmarks on a 200k-node caterpillar tree (JIT-warmed) show
-    deserialization ~2x slower than treeswift. At 200k nodes (with
-    branch lengths): ~2.4s vs treeswift ~1.3s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -282,8 +282,8 @@ def alifestd_from_newick(
     ancestor_list.
 
     Benchmarks on a 200k-node caterpillar tree (JIT-warmed) show
-    deserialization ~2x faster than dendropy and ~6x slower than
-    treeswift. At 200k nodes: ~4s vs dendropy ~9s vs treeswift ~0.6s.
+    deserialization ~7x faster than dendropy and ~2x slower than
+    treeswift. At 200k nodes: ~1.5s vs dendropy ~10s vs treeswift ~0.7s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -1,0 +1,331 @@
+import typing
+
+import numpy as np
+import pandas as pd
+
+from ._alifestd_make_ancestor_list_col import alifestd_make_ancestor_list_col
+from ._jit import jit
+from ._jit_numba_dict_t import jit_numba_dict_t
+from ._jit_numpy_int64_t import jit_numpy_int64_t
+
+
+@jit(nopython=True)
+def _parse_newick(
+    chars: np.ndarray,
+    n: int,
+) -> typing.Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Parse newick string characters into parallel arrays.
+
+    Implementation detail for `alifestd_from_newick`.
+
+    Adapted from
+    https://github.com/niemasd/TreeSwift/blob/63b8979fb5e616ba89079d44e594682683c1365e/treeswift/Tree.py#L1439
+
+    Parameters
+    ----------
+    chars : np.ndarray
+        Array of uint8 character codes for the newick string.
+    n : int
+        Length of chars array.
+
+    Returns
+    -------
+    tuple of np.ndarray
+        (ids, ancestor_ids, branch_lengths, has_branch_length,
+         label_start_stops) where label_start_stops has shape (num_nodes, 2)
+        giving the start (inclusive) and stop (exclusive) index into `chars`
+        for each node's label.
+    """
+    # pre-allocate arrays at maximum possible size (n nodes)
+    ids = np.empty(n, dtype=np.int64)
+    ancestor_ids = np.empty(n, dtype=np.int64)
+    branch_lengths = np.empty(n, dtype=np.float64)
+    has_branch_length = np.zeros(n, dtype=np.int64)
+    label_starts = np.empty(n, dtype=np.int64)
+    label_stops = np.empty(n, dtype=np.int64)
+
+    # character codes
+    LPAREN = np.uint8(40)   # '('
+    RPAREN = np.uint8(41)   # ')'
+    COMMA = np.uint8(44)    # ','
+    COLON = np.uint8(58)    # ':'
+    SEMI = np.uint8(59)     # ';'
+    SQUOTE = np.uint8(39)   # "'"
+    SPACE = np.uint8(32)    # ' '
+    LBRACKET = np.uint8(91) # '['
+    RBRACKET = np.uint8(93) # ']'
+
+    num_nodes = 0
+    # create root node
+    root_id = num_nodes
+    ids[root_id] = root_id
+    ancestor_ids[root_id] = root_id  # root is its own ancestor
+    branch_lengths[root_id] = np.nan
+    label_starts[root_id] = 0
+    label_stops[root_id] = 0
+    num_nodes += 1
+
+    cur = root_id
+    i = 0
+    parse_length = False
+    parse_label = False
+
+    while i < n:
+        c = chars[i]
+
+        # end of newick string
+        if not parse_label and c == SEMI:
+            pass  # done
+
+        # go to new child: '('
+        elif not parse_label and c == LPAREN:
+            child_id = num_nodes
+            ids[child_id] = child_id
+            ancestor_ids[child_id] = cur
+            branch_lengths[child_id] = np.nan
+            label_starts[child_id] = 0
+            label_stops[child_id] = 0
+            num_nodes += 1
+            cur = child_id
+
+        # go to parent: ')'
+        elif not parse_label and c == RPAREN:
+            cur = ancestor_ids[cur]
+
+        # go to new sibling: ','
+        elif not parse_label and c == COMMA:
+            parent = ancestor_ids[cur]
+            child_id = num_nodes
+            ids[child_id] = child_id
+            ancestor_ids[child_id] = parent
+            branch_lengths[child_id] = np.nan
+            label_starts[child_id] = 0
+            label_stops[child_id] = 0
+            num_nodes += 1
+            cur = child_id
+            # skip spaces after comma
+            while i + 1 < n and chars[i + 1] == SPACE:
+                i += 1
+
+        # comment (square brackets)
+        elif not parse_label and c == LBRACKET:
+            count = 1
+            i += 1
+            while i < n and count > 0:
+                if chars[i] == LBRACKET:
+                    count += 1
+                elif chars[i] == RBRACKET:
+                    count -= 1
+                i += 1
+            i -= 1  # will be incremented at end of loop
+
+        # edge length
+        elif not parse_label and c == COLON:
+            parse_length = True
+
+        elif parse_length:
+            ls_start = i
+            while i < n and chars[i] != COMMA and chars[i] != RPAREN and chars[i] != SEMI and chars[i] != LBRACKET:
+                i += 1
+            # parse the accumulated length string
+            # manually parse float from chars[ls_start:i]
+            length = 0.0
+            frac_part = 0.0
+            frac_divisor = 1.0
+            is_negative = False
+            in_frac = False
+            in_exp = False
+            exp_val = 0
+            exp_neg = False
+            j = ls_start
+            if j < i and chars[j] == np.uint8(45):  # '-'
+                is_negative = True
+                j += 1
+            if j < i and chars[j] == np.uint8(43):  # '+'
+                j += 1
+            while j < i:
+                ch = chars[j]
+                if ch == np.uint8(46):  # '.'
+                    in_frac = True
+                elif ch == np.uint8(101) or ch == np.uint8(69):  # 'e' or 'E'
+                    in_exp = True
+                    j += 1
+                    if j < i and chars[j] == np.uint8(45):
+                        exp_neg = True
+                        j += 1
+                    elif j < i and chars[j] == np.uint8(43):
+                        j += 1
+                    continue
+                elif in_exp:
+                    exp_val = exp_val * 10 + (ch - np.uint8(48))
+                elif in_frac:
+                    frac_divisor *= 10.0
+                    frac_part += (ch - np.uint8(48)) / frac_divisor
+                else:
+                    length = length * 10.0 + (ch - np.uint8(48))
+                j += 1
+            length = length + frac_part
+            if is_negative:
+                length = -length
+            if in_exp:
+                if exp_neg:
+                    length = length / (10.0 ** exp_val)
+                else:
+                    length = length * (10.0 ** exp_val)
+            branch_lengths[cur] = length
+            has_branch_length[cur] = 1
+            i -= 1  # will be incremented at end of loop
+            parse_length = False
+
+        # quoted label
+        elif not parse_label and c == SQUOTE:
+            parse_label = True
+
+        # label (quoted or unquoted)
+        else:
+            lbl_start = i
+            while parse_label or (
+                i < n
+                and chars[i] != COLON
+                and chars[i] != COMMA
+                and chars[i] != SEMI
+                and chars[i] != RPAREN
+                and chars[i] != LBRACKET
+            ):
+                if chars[i] == SQUOTE:
+                    parse_label = not parse_label
+                    if not parse_label:
+                        i += 1
+                        break
+                i += 1
+            label_starts[cur] = lbl_start
+            label_stops[cur] = i
+            # strip enclosing quotes from label range if present
+            if (
+                label_stops[cur] > label_starts[cur]
+                and chars[label_starts[cur]] == SQUOTE
+            ):
+                label_starts[cur] += 1
+            if (
+                label_stops[cur] > label_starts[cur]
+                and chars[label_stops[cur] - 1] == SQUOTE
+            ):
+                label_stops[cur] -= 1
+            parse_label = False
+            i -= 1  # will be incremented at end of loop
+
+        i += 1
+
+    # trim to actual size
+    ids_out = ids[:num_nodes].copy()
+    ancestor_ids_out = ancestor_ids[:num_nodes].copy()
+    branch_lengths_out = branch_lengths[:num_nodes].copy()
+    has_branch_length_out = has_branch_length[:num_nodes].copy()
+
+    # pack label start/stops into a 2D array
+    label_start_stops = np.empty((num_nodes, 2), dtype=np.int64)
+    for k in range(num_nodes):
+        label_start_stops[k, 0] = label_starts[k]
+        label_start_stops[k, 1] = label_stops[k]
+
+    return (
+        ids_out,
+        ancestor_ids_out,
+        branch_lengths_out,
+        has_branch_length_out,
+        label_start_stops,
+    )
+
+
+def _extract_labels(
+    newick: str,
+    chars: np.ndarray,
+    label_start_stops: np.ndarray,
+) -> np.ndarray:
+    """Extract taxon labels from newick string using index ranges.
+
+    Implementation detail for `alifestd_from_newick`.
+    """
+    num_nodes = len(label_start_stops)
+    labels = np.empty(num_nodes, dtype=object)
+    for k in range(num_nodes):
+        start = label_start_stops[k, 0]
+        stop = label_start_stops[k, 1]
+        if start == stop:
+            labels[k] = ""
+        else:
+            label = newick[start:stop]
+            # strip enclosing quotes if present
+            if len(label) >= 2 and label[0] == "'" and label[-1] == "'":
+                label = label[1:-1]
+            labels[k] = label
+    return labels
+
+
+def alifestd_from_newick(
+    newick: str,
+) -> pd.DataFrame:
+    """Convert a Newick format string to a phylogeny dataframe.
+
+    Parses a Newick tree string and returns a pandas DataFrame in alife
+    standard format with columns: id, ancestor_list, ancestor_id,
+    taxon_label, origin_time_delta, and branch_length.
+
+    Parameters
+    ----------
+    newick : str
+        A phylogeny in Newick format.
+
+    Returns
+    -------
+    pd.DataFrame
+        Phylogeny dataframe in alife standard format.
+
+    See Also
+    --------
+    alifestd_from_newick_polars :
+        Polars-based implementation.
+    alifestd_as_newick_asexual :
+        Inverse conversion, from alife standard to Newick format.
+    """
+    newick = newick.strip()
+    if not newick:
+        return pd.DataFrame(
+            {
+                "id": pd.Series(dtype=int),
+                "ancestor_list": pd.Series(dtype=str),
+                "ancestor_id": pd.Series(dtype=int),
+                "taxon_label": pd.Series(dtype=str),
+                "origin_time_delta": pd.Series(dtype=float),
+                "branch_length": pd.Series(dtype=float),
+            }
+        )
+
+    chars = np.frombuffer(newick.encode("ascii"), dtype=np.uint8)
+    n = len(chars)
+
+    ids, ancestor_ids, branch_lengths, has_branch_length, label_start_stops = (
+        _parse_newick(chars, n)
+    )
+
+    labels = _extract_labels(newick, chars, label_start_stops)
+
+    # build origin_time_delta: same as branch_length for nodes that have it
+    origin_time_deltas = branch_lengths.copy()
+
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": ids,
+            "ancestor_id": ancestor_ids,
+            "taxon_label": labels,
+            "origin_time_delta": origin_time_deltas,
+            "branch_length": branch_lengths,
+        },
+    )
+
+    phylogeny_df["ancestor_list"] = alifestd_make_ancestor_list_col(
+        phylogeny_df["id"],
+        phylogeny_df["ancestor_id"],
+    )
+
+    return phylogeny_df

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -289,8 +289,8 @@ def _extract_labels(
 
 
 # Performance (as of 2026-03-01, 200k-node caterpillar tree, JIT-warmed):
-#   with branch lengths: hstrat ~1.5s vs treeswift ~1.2s (~1.3x)
-#   without branch lengths: hstrat ~0.7s vs treeswift ~0.5s (~1.4x)
+#   with branch lengths: hstrat ~0.9s vs treeswift ~1.1s (~0.8x)
+#   without branch lengths: hstrat ~0.6s vs treeswift ~1.0s (~0.7x)
 def alifestd_from_newick(
     newick: str,
     *,

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -278,10 +278,9 @@ def alifestd_from_newick(
     standard format with columns: id, ancestor_list, ancestor_id,
     taxon_label, origin_time_delta, and branch_length.
 
-    Benchmarks on synthetic birth-death trees show deserialization at
-    ~4x slower than dendropy and ~15x slower than treeswift, with
-    overhead dominated by DataFrame construction rather than parsing.
-    At 10k nodes: ~450ms vs dendropy ~120ms vs treeswift ~30ms.
+    Benchmarks on a 200k-node caterpillar tree (JIT-warmed) show
+    deserialization ~2x faster than dendropy and ~6x slower than
+    treeswift. At 200k nodes: ~4s vs dendropy ~9s vs treeswift ~0.6s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -289,8 +289,8 @@ def alifestd_from_newick(
     ancestor_list.
 
     Benchmarks on a 200k-node caterpillar tree (JIT-warmed) show
-    deserialization ~7x faster than dendropy and comparable to
-    treeswift. At 200k nodes: dendropy ~10s vs treeswift ~0.7s.
+    deserialization ~2x slower than treeswift. At 200k nodes (with
+    branch lengths): ~2.4s vs treeswift ~1.3s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -14,8 +14,6 @@ from ._eval_kwargs import eval_kwargs
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
 from ._jit import jit
-from ._jit_numba_dict_t import jit_numba_dict_t
-from ._jit_numpy_int64_t import jit_numpy_int64_t
 from ._log_context_duration import log_context_duration
 
 
@@ -313,9 +311,13 @@ def alifestd_from_newick(
     chars = np.frombuffer(newick.encode("ascii"), dtype=np.uint8)
     n = len(chars)
 
-    ids, ancestor_ids, branch_lengths, has_branch_length, label_start_stops = (
-        _parse_newick(chars, n)
-    )
+    (
+        ids,
+        ancestor_ids,
+        branch_lengths,
+        has_branch_length,
+        label_start_stops,
+    ) = _parse_newick(chars, n)
 
     labels = _extract_labels(newick, chars, label_start_stops)
 

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -315,7 +315,7 @@ def alifestd_from_newick(
         ids,
         ancestor_ids,
         branch_lengths,
-        has_branch_length,
+        _,  # has_branch_length
         label_start_stops,
     ) = _parse_newick(chars, n)
 

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -157,18 +157,18 @@ def _parse_newick_jit(
                 i += 1
             i -= 1  # will be incremented at end of loop
 
+        # end of newick string
+        elif c == SEMI:
+            pass
+
         # unquoted label
-        elif not is_lbl_term[c]:
+        else:
             lbl_start = i
             while i < n and not is_lbl_term[chars[i]]:
                 i += 1
             label_starts[cur] = lbl_start
             label_stops[cur] = i
             i -= 1  # will be incremented at end of loop
-
-        # end of newick string (semicolon)
-        else:
-            pass
 
         i += 1
 

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -157,10 +157,6 @@ def _parse_newick_jit(
                 i += 1
             i -= 1  # will be incremented at end of loop
 
-        # end of newick string
-        elif c == SEMI:
-            pass  # done
-
         # unquoted label
         elif not is_lbl_term[c]:
             lbl_start = i
@@ -170,8 +166,9 @@ def _parse_newick_jit(
             label_stops[cur] = i
             i -= 1  # will be incremented at end of loop
 
+        # end of newick string (semicolon)
         else:
-            assert False
+            pass
 
         i += 1
 

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick.py
@@ -278,6 +278,11 @@ def alifestd_from_newick(
     standard format with columns: id, ancestor_list, ancestor_id,
     taxon_label, origin_time_delta, and branch_length.
 
+    Benchmarks on synthetic birth-death trees show deserialization at
+    ~4x slower than dendropy and ~15x slower than treeswift, with
+    overhead dominated by DataFrame construction rather than parsing.
+    At 10k nodes: ~450ms vs dendropy ~120ms vs treeswift ~30ms.
+
     Parameters
     ----------
     newick : str

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -155,11 +155,11 @@ if __name__ == "__main__":
 
     output_ext = os.path.splitext(args.output_file)[1]
     dispatch_writer = {
-        ".csv": lambda df, p, **kw: df.write_csv(p, **kw),
-        ".fea": lambda df, p, **kw: df.write_ipc(p, **kw),
-        ".feather": lambda df, p, **kw: df.write_ipc(p, **kw),
-        ".pqt": lambda df, p, **kw: df.write_parquet(p, **kw),
-        ".parquet": lambda df, p, **kw: df.write_parquet(p, **kw),
+        ".csv": pl.DataFrame.write_csv,
+        ".fea": pl.DataFrame.write_ipc,
+        ".feather": pl.DataFrame.write_ipc,
+        ".pqt": pl.DataFrame.write_parquet,
+        ".parquet": pl.DataFrame.write_parquet,
     }
 
     logging.info(

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -60,7 +60,7 @@ def alifestd_from_newick_polars(
         ids,
         ancestor_ids,
         branch_lengths,
-        has_branch_length,
+        _,  # has_branch_length
         label_start_stops,
     ) = _parse_newick(chars, n)
 

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -27,8 +27,8 @@ def alifestd_from_newick_polars(
     ancestor_list.
 
     Benchmarks on a 200k-node caterpillar tree (JIT-warmed) show
-    deserialization ~2x faster than dendropy and ~6x slower than
-    treeswift. At 200k nodes: ~4s vs dendropy ~9s vs treeswift ~0.6s.
+    deserialization ~7x faster than dendropy and ~2x slower than
+    treeswift. At 200k nodes: ~1.5s vs dendropy ~10s vs treeswift ~0.7s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -1,0 +1,75 @@
+import numpy as np
+import polars as pl
+
+from ._alifestd_from_newick import _extract_labels
+from ._alifestd_from_newick import _parse_newick
+
+
+def alifestd_from_newick_polars(
+    newick: str,
+) -> pl.DataFrame:
+    """Convert a Newick format string to a phylogeny dataframe.
+
+    Parses a Newick tree string and returns a polars DataFrame in alife
+    standard format with columns: id, ancestor_list, ancestor_id,
+    taxon_label, origin_time_delta, and branch_length.
+
+    Parameters
+    ----------
+    newick : str
+        A phylogeny in Newick format.
+
+    Returns
+    -------
+    pl.DataFrame
+        Phylogeny dataframe in alife standard format.
+
+    See Also
+    --------
+    alifestd_from_newick :
+        Pandas-based implementation.
+    alifestd_as_newick_asexual :
+        Inverse conversion, from alife standard to Newick format.
+    """
+    newick = newick.strip()
+    if not newick:
+        return pl.DataFrame(
+            {
+                "id": pl.Series([], dtype=pl.Int64),
+                "ancestor_list": pl.Series([], dtype=pl.Utf8),
+                "ancestor_id": pl.Series([], dtype=pl.Int64),
+                "taxon_label": pl.Series([], dtype=pl.Utf8),
+                "origin_time_delta": pl.Series([], dtype=pl.Float64),
+                "branch_length": pl.Series([], dtype=pl.Float64),
+            }
+        )
+
+    chars = np.frombuffer(newick.encode("ascii"), dtype=np.uint8)
+    n = len(chars)
+
+    ids, ancestor_ids, branch_lengths, has_branch_length, label_start_stops = (
+        _parse_newick(chars, n)
+    )
+
+    labels = _extract_labels(newick, chars, label_start_stops)
+
+    origin_time_deltas = branch_lengths.copy()
+
+    # build ancestor_list column
+    ancestor_list = []
+    for id_, anc_id in zip(ids, ancestor_ids):
+        if id_ == anc_id:
+            ancestor_list.append("[none]")
+        else:
+            ancestor_list.append(f"[{anc_id}]")
+
+    return pl.DataFrame(
+        {
+            "id": pl.Series(ids, dtype=pl.Int64),
+            "ancestor_list": pl.Series(ancestor_list, dtype=pl.Utf8),
+            "ancestor_id": pl.Series(ancestor_ids, dtype=pl.Int64),
+            "taxon_label": pl.Series(labels.tolist(), dtype=pl.Utf8),
+            "origin_time_delta": pl.Series(origin_time_deltas, dtype=pl.Float64),
+            "branch_length": pl.Series(branch_lengths, dtype=pl.Float64),
+        }
+    )

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -14,6 +14,7 @@ from ._get_hstrat_version import get_hstrat_version
 from ._log_context_duration import log_context_duration
 
 
+# Performance: see _alifestd_from_newick.py for benchmark numbers.
 def alifestd_from_newick_polars(
     newick: str,
     *,
@@ -26,10 +27,6 @@ def alifestd_from_newick_polars(
     standard format with columns: id, ancestor_id, taxon_label,
     origin_time_delta, and branch_length. Optionally includes
     ancestor_list.
-
-    Benchmarks on a 200k-node caterpillar tree (JIT-warmed) show
-    deserialization ~2x slower than treeswift. At 200k nodes (with
-    branch lengths): ~2.4s vs treeswift ~1.3s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -23,10 +23,9 @@ def alifestd_from_newick_polars(
     standard format with columns: id, ancestor_list, ancestor_id,
     taxon_label, origin_time_delta, and branch_length.
 
-    Benchmarks on synthetic birth-death trees show deserialization at
-    ~4x slower than dendropy and ~15x slower than treeswift, with
-    overhead dominated by DataFrame construction rather than parsing.
-    At 10k nodes: ~450ms vs dendropy ~120ms vs treeswift ~30ms.
+    Benchmarks on a 200k-node caterpillar tree (JIT-warmed) show
+    deserialization ~2x faster than dendropy and ~6x slower than
+    treeswift. At 200k nodes: ~4s vs dendropy ~9s vs treeswift ~0.6s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -27,8 +27,8 @@ def alifestd_from_newick_polars(
     ancestor_list.
 
     Benchmarks on a 200k-node caterpillar tree (JIT-warmed) show
-    deserialization ~7x faster than dendropy and ~2x slower than
-    treeswift. At 200k nodes: ~1.5s vs dendropy ~10s vs treeswift ~0.7s.
+    deserialization ~7x faster than dendropy and comparable to
+    treeswift. At 200k nodes: dendropy ~10s vs treeswift ~0.7s.
 
     Parameters
     ----------
@@ -71,7 +71,7 @@ def alifestd_from_newick_polars(
         branch_lengths,
         _,  # has_branch_length
         label_start_stops,
-    ) = _parse_newick(chars, n)
+    ) = _parse_newick(newick, chars, n)
 
     labels = _extract_labels(newick, chars, label_start_stops)
 

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -71,7 +71,6 @@ def alifestd_from_newick_polars(
         ids,
         ancestor_ids,
         branch_lengths,
-        _,  # has_branch_length
         label_start_stops,
     ) = _parse_newick(newick, chars, n)
 

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -56,9 +56,13 @@ def alifestd_from_newick_polars(
     chars = np.frombuffer(newick.encode("ascii"), dtype=np.uint8)
     n = len(chars)
 
-    ids, ancestor_ids, branch_lengths, has_branch_length, label_start_stops = (
-        _parse_newick(chars, n)
-    )
+    (
+        ids,
+        ancestor_ids,
+        branch_lengths,
+        has_branch_length,
+        label_start_stops,
+    ) = _parse_newick(chars, n)
 
     labels = _extract_labels(newick, chars, label_start_stops)
 

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -23,6 +23,11 @@ def alifestd_from_newick_polars(
     standard format with columns: id, ancestor_list, ancestor_id,
     taxon_label, origin_time_delta, and branch_length.
 
+    Benchmarks on synthetic birth-death trees show deserialization at
+    ~4x slower than dendropy and ~15x slower than treeswift, with
+    overhead dominated by DataFrame construction rather than parsing.
+    At 10k nodes: ~450ms vs dendropy ~120ms vs treeswift ~30ms.
+
     Parameters
     ----------
     newick : str

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -27,8 +27,8 @@ def alifestd_from_newick_polars(
     ancestor_list.
 
     Benchmarks on a 200k-node caterpillar tree (JIT-warmed) show
-    deserialization ~7x faster than dendropy and comparable to
-    treeswift. At 200k nodes: dendropy ~10s vs treeswift ~0.7s.
+    deserialization ~2x slower than treeswift. At 200k nodes (with
+    branch lengths): ~2.4s vs treeswift ~1.3s.
 
     Parameters
     ----------

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -132,6 +132,19 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Path to write Alife standard dataframe output to.",
     )
     parser.add_argument(
+        "--branch-length-dtype",
+        type=str,
+        choices=["float", "int"],
+        default="float",
+        help="Dtype for branch length values. Defaults to 'float'.",
+    )
+    parser.add_argument(
+        "--create-ancestor-list",
+        action="store_true",
+        default=False,
+        help="Include an ancestor_list column in the output.",
+    )
+    parser.add_argument(
         "--output-kwarg",
         action="append",
         dest="output_kwargs",
@@ -154,6 +167,9 @@ def _create_parser() -> argparse.ArgumentParser:
     return parser
 
 
+_dtype_lookup = {"float": float, "int": int}
+
+
 if __name__ == "__main__":
     configure_prod_logging()
 
@@ -167,7 +183,11 @@ if __name__ == "__main__":
         "hstrat._auxiliary_lib.alifestd_from_newick_polars", logging.info
     ):
         logging.info("converting from Newick format...")
-        phylogeny_df = alifestd_from_newick_polars(newick_str)
+        phylogeny_df = alifestd_from_newick_polars(
+            newick_str,
+            branch_length_dtype=_dtype_lookup[args.branch_length_dtype],
+            create_ancestor_list=args.create_ancestor_list,
+        )
 
     output_ext = os.path.splitext(args.output_file)[1]
     output_kwargs = eval_kwargs(args.output_kwargs)

--- a/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_from_newick_polars.py
@@ -72,7 +72,7 @@ def alifestd_from_newick_polars(
         ancestor_ids,
         branch_lengths,
         label_start_stops,
-    ) = _parse_newick(newick, chars, n)
+    ) = _parse_newick(newick, chars, n, branch_length_dtype)
 
     labels = _extract_labels(newick, chars, label_start_stops)
 

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
@@ -125,8 +125,7 @@ def test_branch_lengths():
 
     # internal node with branch length 7
     internal = result[
-        (result["taxon_label"] == "")
-        & (result["ancestor_id"] != result["id"])
+        (result["taxon_label"] == "") & (result["ancestor_id"] != result["id"])
     ]
     assert len(internal) == 1
     assert internal["branch_length"].iloc[0] == pytest.approx(7.0)
@@ -267,9 +266,7 @@ def test_roundtrip(phylogeny_df: pd.DataFrame):
     assert len(reconstructed) == len(phylogeny_df)
 
     # build parent mapping from reconstructed data using taxon_labels as ids
-    taxon_labels = dict(
-        zip(reconstructed["id"], reconstructed["taxon_label"])
-    )
+    taxon_labels = dict(zip(reconstructed["id"], reconstructed["taxon_label"]))
     reconstructed_edges = set()
     for _, row in reconstructed.iterrows():
         child_label = row["taxon_label"]

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
@@ -551,18 +551,18 @@ def test_branch_length_dtype_int():
         "(ant:17,(bat:31,cow:22):7,dog:22);",
         branch_length_dtype=int,
     )
-    assert result["branch_length"].dtype == np.int64
+    assert result["branch_length"].dtype == pd.Int64Dtype()
     ant = result[result["taxon_label"] == "ant"]
     assert ant["branch_length"].iloc[0] == 17
-    # missing branch length should be -1
+    # missing branch length should be pd.NA (null)
     root = result[result["ancestor_id"] == result["id"]]
-    assert root["branch_length"].iloc[0] == -1
+    assert pd.isna(root["branch_length"].iloc[0])
 
 
 def test_branch_length_dtype_int_no_lengths():
     result = alifestd_from_newick("(A,B)C;", branch_length_dtype=int)
-    assert result["branch_length"].dtype == np.int64
-    assert (result["branch_length"] == -1).all()
+    assert result["branch_length"].dtype == pd.Int64Dtype()
+    assert result["branch_length"].isna().all()
 
 
 def test_star_tree():

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
@@ -1,0 +1,316 @@
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from hstrat._auxiliary_lib import (
+    alifestd_as_newick_asexual,
+    alifestd_from_newick,
+    alifestd_make_empty,
+    alifestd_try_add_ancestor_id_col,
+)
+
+assets_path = os.path.join(os.path.dirname(__file__), "assets")
+
+
+def test_empty():
+    result = alifestd_from_newick("")
+    assert len(result) == 0
+    assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+    assert "ancestor_id" in result.columns
+    assert "taxon_label" in result.columns
+    assert "origin_time_delta" in result.columns
+    assert "branch_length" in result.columns
+
+
+def test_just_root():
+    result = alifestd_from_newick("root;")
+    assert len(result) == 1
+    assert result["id"].iloc[0] == 0
+    assert result["ancestor_id"].iloc[0] == 0  # root is own ancestor
+    assert result["taxon_label"].iloc[0] == "root"
+    assert result["ancestor_list"].iloc[0] == "[none]"
+
+
+def test_just_root_no_label():
+    result = alifestd_from_newick(";")
+    assert len(result) == 1
+    assert result["id"].iloc[0] == 0
+    assert result["ancestor_id"].iloc[0] == 0
+    assert result["taxon_label"].iloc[0] == ""
+
+
+def test_onlychild():
+    result = alifestd_from_newick("(child)root;")
+    assert len(result) == 2
+
+    root = result[result["taxon_label"] == "root"]
+    child = result[result["taxon_label"] == "child"]
+
+    assert len(root) == 1
+    assert len(child) == 1
+    assert root["ancestor_id"].iloc[0] == root["id"].iloc[0]
+    assert child["ancestor_id"].iloc[0] == root["id"].iloc[0]
+
+
+def test_twins():
+    result = alifestd_from_newick("(twin1,twin2)root;")
+    assert len(result) == 3
+
+    root = result[result["taxon_label"] == "root"]
+    twin1 = result[result["taxon_label"] == "twin1"]
+    twin2 = result[result["taxon_label"] == "twin2"]
+
+    assert len(root) == 1
+    assert len(twin1) == 1
+    assert len(twin2) == 1
+    assert twin1["ancestor_id"].iloc[0] == root["id"].iloc[0]
+    assert twin2["ancestor_id"].iloc[0] == root["id"].iloc[0]
+
+
+def test_triplets():
+    result = alifestd_from_newick("(triplet1,triplet2,triplet3)root;")
+    assert len(result) == 4
+
+    root = result[result["taxon_label"] == "root"]
+    for name in ["triplet1", "triplet2", "triplet3"]:
+        child = result[result["taxon_label"] == name]
+        assert len(child) == 1
+        assert child["ancestor_id"].iloc[0] == root["id"].iloc[0]
+
+
+def test_grandchild():
+    result = alifestd_from_newick("((child)parent)root;")
+    assert len(result) == 3
+
+    root = result[result["taxon_label"] == "root"]
+    parent = result[result["taxon_label"] == "parent"]
+    child = result[result["taxon_label"] == "child"]
+
+    assert root["ancestor_id"].iloc[0] == root["id"].iloc[0]
+    assert parent["ancestor_id"].iloc[0] == root["id"].iloc[0]
+    assert child["ancestor_id"].iloc[0] == parent["id"].iloc[0]
+
+
+def test_grandchild_and_aunt():
+    result = alifestd_from_newick("((child)parent,aunt)root;")
+    assert len(result) == 4
+
+    root = result[result["taxon_label"] == "root"]
+    parent = result[result["taxon_label"] == "parent"]
+    child = result[result["taxon_label"] == "child"]
+    aunt = result[result["taxon_label"] == "aunt"]
+
+    assert parent["ancestor_id"].iloc[0] == root["id"].iloc[0]
+    assert child["ancestor_id"].iloc[0] == parent["id"].iloc[0]
+    assert aunt["ancestor_id"].iloc[0] == root["id"].iloc[0]
+
+
+def test_branch_lengths():
+    result = alifestd_from_newick("(ant:17,(bat:31,cow:22):7,dog:22);")
+    # root + ant + internal + bat + cow + dog = 6 nodes
+    assert len(result) == 6
+
+    ant = result[result["taxon_label"] == "ant"]
+    bat = result[result["taxon_label"] == "bat"]
+    cow = result[result["taxon_label"] == "cow"]
+    dog = result[result["taxon_label"] == "dog"]
+
+    assert ant["branch_length"].iloc[0] == pytest.approx(17.0)
+    assert bat["branch_length"].iloc[0] == pytest.approx(31.0)
+    assert cow["branch_length"].iloc[0] == pytest.approx(22.0)
+    assert dog["branch_length"].iloc[0] == pytest.approx(22.0)
+
+    # internal node with branch length 7
+    internal = result[
+        (result["taxon_label"] == "")
+        & (result["ancestor_id"] != result["id"])
+    ]
+    assert len(internal) == 1
+    assert internal["branch_length"].iloc[0] == pytest.approx(7.0)
+
+    # origin_time_delta matches branch_length
+    assert (
+        result["origin_time_delta"].dropna()
+        == result["branch_length"].dropna()
+    ).all()
+
+
+def test_branch_lengths_float():
+    result = alifestd_from_newick("(A:0.1,B:0.2,(C:0.3,D:0.4):0.5);")
+    a = result[result["taxon_label"] == "A"]
+    b = result[result["taxon_label"] == "B"]
+    c = result[result["taxon_label"] == "C"]
+    d = result[result["taxon_label"] == "D"]
+
+    assert a["branch_length"].iloc[0] == pytest.approx(0.1)
+    assert b["branch_length"].iloc[0] == pytest.approx(0.2)
+    assert c["branch_length"].iloc[0] == pytest.approx(0.3)
+    assert d["branch_length"].iloc[0] == pytest.approx(0.4)
+
+
+def test_no_branch_length_is_nan():
+    result = alifestd_from_newick("(A,B)C;")
+    assert np.isnan(result["branch_length"].iloc[0])  # root C
+    assert np.isnan(result["branch_length"].iloc[1])  # A
+    assert np.isnan(result["branch_length"].iloc[2])  # B
+
+
+def test_mixed_branch_lengths():
+    result = alifestd_from_newick("(A:5,B)C;")
+    a = result[result["taxon_label"] == "A"]
+    b = result[result["taxon_label"] == "B"]
+    assert a["branch_length"].iloc[0] == pytest.approx(5.0)
+    assert np.isnan(b["branch_length"].iloc[0])
+
+
+def test_ancestor_list_col():
+    result = alifestd_from_newick("(A,B)C;")
+    root = result[result["taxon_label"] == "C"]
+    a = result[result["taxon_label"] == "A"]
+    b = result[result["taxon_label"] == "B"]
+
+    assert root["ancestor_list"].iloc[0] == "[none]"
+    assert a["ancestor_list"].iloc[0] == f"[{root['id'].iloc[0]}]"
+    assert b["ancestor_list"].iloc[0] == f"[{root['id'].iloc[0]}]"
+
+
+def test_example_newick():
+    newick = "(ant:17, (bat:31, cow:22):7, dog:22, (elk:33, fox:12):40);"
+    result = alifestd_from_newick(newick)
+    # root + ant + internal1 + bat + cow + dog + internal2 + elk + fox = 9
+    assert len(result) == 9
+
+    fox = result[result["taxon_label"] == "fox"]
+    assert fox["branch_length"].iloc[0] == pytest.approx(12.0)
+
+    elk = result[result["taxon_label"] == "elk"]
+    assert elk["branch_length"].iloc[0] == pytest.approx(33.0)
+
+
+def test_quoted_labels():
+    result = alifestd_from_newick("('node A','node B')'root node';")
+    assert len(result) == 3
+    labels = set(result["taxon_label"])
+    assert "node A" in labels
+    assert "node B" in labels
+    assert "root node" in labels
+
+
+def test_contiguous_ids():
+    result = alifestd_from_newick(
+        "(((grandchild1, grandchild2)triplet1,triplet2,triplet3)parent,aunt,uncle)root;"
+    )
+    assert list(result["id"]) == list(range(len(result)))
+
+
+@pytest.mark.parametrize(
+    "newick_file",
+    [
+        "grandchild.newick",
+        "grandchild_and_aunt.newick",
+        "grandchild_and_auntuncle.newick",
+        "grandtriplets.newick",
+        "grandtriplets_and_aunt.newick",
+        "grandtriplets_and_auntuncle.newick",
+        "grandtwins.newick",
+        "grandtwins_and_aunt.newick",
+        "grandtwins_and_auntuncle.newick",
+        "greatgrandtwins_and_auntuncle.newick",
+        "justroot.newick",
+        "onlychild.newick",
+        "triplets.newick",
+        "twins.newick",
+    ],
+)
+def test_newick_assets(newick_file: str):
+    newick_path = os.path.join(
+        os.path.dirname(__file__), "..", "assets", newick_file
+    )
+    newick = open(newick_path).read().strip()
+    result = alifestd_from_newick(newick)
+
+    assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+    assert "ancestor_id" in result.columns
+    assert "taxon_label" in result.columns
+
+    # root should have ancestor_id == id
+    roots = result[result["ancestor_id"] == result["id"]]
+    assert len(roots) >= 1
+
+    # all non-root ancestor_ids should reference valid ids
+    non_root = result[result["ancestor_id"] != result["id"]]
+    assert non_root["ancestor_id"].isin(result["id"]).all()
+
+
+@pytest.mark.parametrize(
+    "phylogeny_df",
+    [
+        pd.read_csv(
+            f"{assets_path}/example-standard-toy-asexual-phylogeny.csv"
+        ),
+        pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv"),
+        pd.read_csv(f"{assets_path}/nk_lexicaseselection.csv"),
+        pd.read_csv(f"{assets_path}/nk_tournamentselection.csv"),
+    ],
+)
+def test_roundtrip(phylogeny_df: pd.DataFrame):
+    """Test roundtrip: alife -> newick -> alife preserves topology."""
+    phylogeny_df = alifestd_try_add_ancestor_id_col(phylogeny_df)
+
+    newick = alifestd_as_newick_asexual(phylogeny_df, taxon_label="id")
+    reconstructed = alifestd_from_newick(newick)
+
+    assert len(reconstructed) == len(phylogeny_df)
+
+    # build parent mapping from reconstructed data using taxon_labels as ids
+    taxon_labels = dict(
+        zip(reconstructed["id"], reconstructed["taxon_label"])
+    )
+    reconstructed_edges = set()
+    for _, row in reconstructed.iterrows():
+        child_label = row["taxon_label"]
+        if row["ancestor_id"] != row["id"]:
+            parent_label = taxon_labels[row["ancestor_id"]]
+            reconstructed_edges.add((int(child_label), int(parent_label)))
+        else:
+            reconstructed_edges.add((int(child_label), int(child_label)))
+
+    original_edges = set()
+    for _, row in phylogeny_df.iterrows():
+        original_edges.add((int(row["id"]), int(row["ancestor_id"])))
+
+    assert reconstructed_edges == original_edges
+
+
+def test_whitespace_handling():
+    result1 = alifestd_from_newick("(A,B)C;")
+    result2 = alifestd_from_newick("  (A,B)C;  ")
+    assert len(result1) == len(result2)
+    assert list(result1["taxon_label"]) == list(result2["taxon_label"])
+
+
+def test_comments_ignored():
+    result = alifestd_from_newick("(A[comment],B)C;")
+    assert len(result) == 3
+    labels = set(result["taxon_label"])
+    assert "A" in labels
+    assert "B" in labels
+    assert "C" in labels
+
+
+def test_negative_branch_length():
+    result = alifestd_from_newick("(A:-1.5,B:2.0);")
+    a = result[result["taxon_label"] == "A"]
+    assert a["branch_length"].iloc[0] == pytest.approx(-1.5)
+
+
+def test_scientific_notation():
+    result = alifestd_from_newick("(A:1.5e-3,B:2E4);")
+    a = result[result["taxon_label"] == "A"]
+    b = result[result["taxon_label"] == "B"]
+    assert a["branch_length"].iloc[0] == pytest.approx(1.5e-3)
+    assert b["branch_length"].iloc[0] == pytest.approx(2e4)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
@@ -18,15 +18,18 @@ def test_empty():
     result = alifestd_from_newick("")
     assert len(result) == 0
     assert "id" in result.columns
-    assert "ancestor_list" in result.columns
+    assert "ancestor_list" not in result.columns
     assert "ancestor_id" in result.columns
     assert "taxon_label" in result.columns
     assert "origin_time_delta" in result.columns
     assert "branch_length" in result.columns
 
+    result_with_al = alifestd_from_newick("", create_ancestor_list=True)
+    assert "ancestor_list" in result_with_al.columns
+
 
 def test_just_root():
-    result = alifestd_from_newick("root;")
+    result = alifestd_from_newick("root;", create_ancestor_list=True)
     assert len(result) == 1
     assert result["id"].iloc[0] == 0
     assert result["ancestor_id"].iloc[0] == 0  # root is own ancestor
@@ -166,7 +169,7 @@ def test_mixed_branch_lengths():
 
 
 def test_ancestor_list_col():
-    result = alifestd_from_newick("(A,B)C;")
+    result = alifestd_from_newick("(A,B)C;", create_ancestor_list=True)
     root = result[result["taxon_label"] == "C"]
     a = result[result["taxon_label"] == "A"]
     b = result[result["taxon_label"] == "B"]
@@ -174,6 +177,9 @@ def test_ancestor_list_col():
     assert root["ancestor_list"].iloc[0] == "[none]"
     assert a["ancestor_list"].iloc[0] == f"[{root['id'].iloc[0]}]"
     assert b["ancestor_list"].iloc[0] == f"[{root['id'].iloc[0]}]"
+
+    result_no_al = alifestd_from_newick("(A,B)C;")
+    assert "ancestor_list" not in result_no_al.columns
 
 
 def test_example_newick():
@@ -229,7 +235,7 @@ def test_newick_assets(newick_file: str):
         os.path.dirname(__file__), "..", "assets", newick_file
     )
     newick = pathlib.Path(newick_path).read_text().strip()
-    result = alifestd_from_newick(newick)
+    result = alifestd_from_newick(newick, create_ancestor_list=True)
 
     assert "id" in result.columns
     assert "ancestor_list" in result.columns

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
@@ -244,6 +244,11 @@ def test_newick_assets(newick_file: str):
     non_root = result[result["ancestor_id"] != result["id"]]
     assert non_root["ancestor_id"].isin(result["id"]).all()
 
+    # roundtrip: newick -> alife -> newick -> alife preserves topology
+    re_newick = alifestd_as_newick_asexual(result, taxon_label="taxon_label")
+    re_result = alifestd_from_newick(re_newick)
+    assert len(re_result) == len(result)
+
 
 @pytest.mark.parametrize(
     "phylogeny_df",

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 import numpy as np
 import pandas as pd
@@ -7,7 +8,6 @@ import pytest
 from hstrat._auxiliary_lib import (
     alifestd_as_newick_asexual,
     alifestd_from_newick,
-    alifestd_make_empty,
     alifestd_try_add_ancestor_id_col,
 )
 
@@ -228,7 +228,7 @@ def test_newick_assets(newick_file: str):
     newick_path = os.path.join(
         os.path.dirname(__file__), "..", "assets", newick_file
     )
-    newick = open(newick_path).read().strip()
+    newick = pathlib.Path(newick_path).read_text().strip()
     result = alifestd_from_newick(newick)
 
     assert "id" in result.columns

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick_polars.py
@@ -220,18 +220,21 @@ def test_alifestd_asset_roundtrip(
     assert len(roots) == 1
 
     if taxon_label == "id":
-        # extract columns from polars result
-        r_ids = reconstructed["id"].to_list()
-        r_ancestor_ids = reconstructed["ancestor_id"].to_list()
-        r_labels = reconstructed["taxon_label"].to_list()
-        id_to_label = dict(zip(r_ids, r_labels))
+        # compare edges using polars column extraction
+        id_to_label = dict(
+            zip(
+                reconstructed["id"].to_list(),
+                reconstructed["taxon_label"].to_list(),
+            )
+        )
         reconstructed_edges = set()
-        for rid, raid, label in zip(r_ids, r_ancestor_ids, r_labels):
-            if rid != raid:
-                parent_label = id_to_label[raid]
-                reconstructed_edges.add((int(label), int(parent_label)))
-            else:
-                reconstructed_edges.add((int(label), int(label)))
+        for rid, raid in zip(
+            reconstructed["id"].to_list(),
+            reconstructed["ancestor_id"].to_list(),
+        ):
+            label = id_to_label[rid]
+            parent_label = id_to_label[raid]
+            reconstructed_edges.add((int(label), int(parent_label)))
 
         original_edges = set()
         for _, row in phylogeny_df.iterrows():

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick_polars.py
@@ -1,0 +1,132 @@
+import os
+
+import numpy as np
+import polars as pl
+import pytest
+
+from hstrat._auxiliary_lib import (
+    alifestd_from_newick,
+    alifestd_from_newick_polars,
+)
+
+
+def test_empty():
+    result = alifestd_from_newick_polars("")
+    assert len(result) == 0
+    assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+    assert "ancestor_id" in result.columns
+    assert "taxon_label" in result.columns
+    assert "origin_time_delta" in result.columns
+    assert "branch_length" in result.columns
+
+
+def test_just_root():
+    result = alifestd_from_newick_polars("root;")
+    assert len(result) == 1
+    assert result["id"][0] == 0
+    assert result["ancestor_id"][0] == 0
+    assert result["taxon_label"][0] == "root"
+    assert result["ancestor_list"][0] == "[none]"
+
+
+def test_twins():
+    result = alifestd_from_newick_polars("(twin1,twin2)root;")
+    assert len(result) == 3
+    assert isinstance(result, pl.DataFrame)
+
+    root = result.filter(pl.col("taxon_label") == "root")
+    twin1 = result.filter(pl.col("taxon_label") == "twin1")
+    twin2 = result.filter(pl.col("taxon_label") == "twin2")
+
+    assert twin1["ancestor_id"][0] == root["id"][0]
+    assert twin2["ancestor_id"][0] == root["id"][0]
+
+
+def test_branch_lengths():
+    result = alifestd_from_newick_polars(
+        "(ant:17,(bat:31,cow:22):7,dog:22);"
+    )
+    # root + ant + internal + bat + cow + dog = 6
+    assert len(result) == 6
+
+    ant = result.filter(pl.col("taxon_label") == "ant")
+    assert ant["branch_length"][0] == pytest.approx(17.0)
+    assert ant["origin_time_delta"][0] == pytest.approx(17.0)
+
+
+def test_grandchild():
+    result = alifestd_from_newick_polars("((child)parent)root;")
+    assert len(result) == 3
+
+    root = result.filter(pl.col("taxon_label") == "root")
+    parent = result.filter(pl.col("taxon_label") == "parent")
+    child = result.filter(pl.col("taxon_label") == "child")
+
+    assert root["ancestor_id"][0] == root["id"][0]
+    assert parent["ancestor_id"][0] == root["id"][0]
+    assert child["ancestor_id"][0] == parent["id"][0]
+
+
+def test_no_branch_length_is_null():
+    result = alifestd_from_newick_polars("(A,B)C;")
+    assert result["branch_length"].is_nan().sum() == 3
+
+
+@pytest.mark.parametrize(
+    "newick_file",
+    [
+        "grandchild.newick",
+        "grandchild_and_aunt.newick",
+        "justroot.newick",
+        "onlychild.newick",
+        "triplets.newick",
+        "twins.newick",
+    ],
+)
+def test_newick_assets(newick_file: str):
+    newick_path = os.path.join(
+        os.path.dirname(__file__), "..", "assets", newick_file
+    )
+    newick = open(newick_path).read().strip()
+    result = alifestd_from_newick_polars(newick)
+
+    assert isinstance(result, pl.DataFrame)
+    assert "id" in result.columns
+    assert "ancestor_list" in result.columns
+    assert "taxon_label" in result.columns
+
+    # root should have ancestor_id == id
+    roots = result.filter(pl.col("ancestor_id") == pl.col("id"))
+    assert len(roots) >= 1
+
+
+def test_matches_pandas():
+    """Verify polars output matches pandas output."""
+    newick = "(ant:17,(bat:31,cow:22):7,dog:22,(elk:33,fox:12):40);"
+    pd_result = alifestd_from_newick(newick)
+    pl_result = alifestd_from_newick_polars(newick)
+
+    assert len(pd_result) == len(pl_result)
+
+    for col in ["id", "ancestor_id", "taxon_label", "ancestor_list"]:
+        assert list(pd_result[col]) == pl_result[col].to_list()
+
+    # compare branch lengths (with nan handling)
+    pd_bl = pd_result["branch_length"].tolist()
+    pl_bl = pl_result["branch_length"].to_list()
+    for a, b in zip(pd_bl, pl_bl):
+        if a != a:  # nan check
+            assert b != b
+        else:
+            assert a == pytest.approx(b)
+
+
+def test_column_dtypes():
+    result = alifestd_from_newick_polars("(A:1,B:2)C;")
+    assert result["id"].dtype == pl.Int64
+    assert result["ancestor_id"].dtype == pl.Int64
+    assert result["taxon_label"].dtype == pl.Utf8
+    assert result["ancestor_list"].dtype == pl.Utf8
+    assert result["origin_time_delta"].dtype == pl.Float64
+    assert result["branch_length"].dtype == pl.Float64

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick_polars.py
@@ -1,6 +1,6 @@
 import os
+import pathlib
 
-import numpy as np
 import polars as pl
 import pytest
 
@@ -86,7 +86,7 @@ def test_newick_assets(newick_file: str):
     newick_path = os.path.join(
         os.path.dirname(__file__), "..", "assets", newick_file
     )
-    newick = open(newick_path).read().strip()
+    newick = pathlib.Path(newick_path).read_text().strip()
     result = alifestd_from_newick_polars(newick)
 
     assert isinstance(result, pl.DataFrame)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick_polars.py
@@ -44,9 +44,7 @@ def test_twins():
 
 
 def test_branch_lengths():
-    result = alifestd_from_newick_polars(
-        "(ant:17,(bat:31,cow:22):7,dog:22);"
-    )
+    result = alifestd_from_newick_polars("(ant:17,(bat:31,cow:22):7,dog:22);")
     # root + ant + internal + bat + cow + dog = 6
     assert len(result) == 6
 

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_from_newick_polars.py
@@ -1,6 +1,8 @@
 import os
 import pathlib
 
+import numpy as np
+import pandas as pd
 import polars as pl
 import pytest
 
@@ -8,7 +10,10 @@ from hstrat._auxiliary_lib import (
     alifestd_as_newick_asexual,
     alifestd_from_newick,
     alifestd_from_newick_polars,
+    alifestd_try_add_ancestor_id_col,
 )
+
+assets_path = os.path.join(os.path.dirname(__file__), "assets")
 
 
 def test_empty():
@@ -157,3 +162,79 @@ def test_roundtrip(newick_file: str):
     )
     re_result = alifestd_from_newick_polars(re_newick)
     assert len(re_result) == len(result)
+
+
+@pytest.mark.parametrize(
+    "phylogeny_csv",
+    [
+        "example-standard-toy-asexual-phylogeny.csv",
+        "example-standard-toy-asexual-phylogeny-noncompact1.csv",
+        "example-standard-toy-asexual-phylogeny-noncompact2.csv",
+        "example-standard-toy-asexual-phylogeny-uniq.csv",
+        "nk_ecoeaselection.csv",
+        "nk_lexicaseselection.csv",
+        "nk_tournamentselection.csv",
+        "prunetestphylo.csv",
+        "collapse_unifurcations_testphylo.csv",
+    ],
+)
+@pytest.mark.parametrize("taxon_label", [None, "id"])
+@pytest.mark.parametrize("with_branch_length", [True, False])
+def test_alifestd_asset_roundtrip(
+    phylogeny_csv, taxon_label, with_branch_length
+):
+    """Test roundtrip: alifestd -> newick -> polars alife using assets."""
+    phylogeny_df = pd.read_csv(f"{assets_path}/{phylogeny_csv}")
+    phylogeny_df = alifestd_try_add_ancestor_id_col(phylogeny_df)
+
+    if with_branch_length:
+        if (
+            "origin_time_delta" not in phylogeny_df.columns
+            and "origin_time" not in phylogeny_df.columns
+        ):
+            phylogeny_df["origin_time_delta"] = np.arange(
+                len(phylogeny_df), dtype=float
+            )
+    else:
+        phylogeny_df = phylogeny_df.drop(
+            columns=["origin_time", "origin_time_delta"],
+            errors="ignore",
+        )
+
+    newick = alifestd_as_newick_asexual(
+        phylogeny_df,
+        taxon_label=taxon_label,
+    )
+    reconstructed = alifestd_from_newick_polars(newick)
+
+    assert len(reconstructed) == len(phylogeny_df)
+    assert isinstance(reconstructed, pl.DataFrame)
+
+    # verify single root
+    roots = reconstructed.filter(pl.col("ancestor_id") == pl.col("id"))
+    assert len(roots) == 1
+
+    if taxon_label == "id":
+        # verify exact topology via pandas for easier iteration
+        pd_result = alifestd_from_newick(newick)
+        taxon_labels = dict(zip(pd_result["id"], pd_result["taxon_label"]))
+        reconstructed_edges = set()
+        for _, row in pd_result.iterrows():
+            child_label = row["taxon_label"]
+            if row["ancestor_id"] != row["id"]:
+                parent_label = taxon_labels[row["ancestor_id"]]
+                reconstructed_edges.add((int(child_label), int(parent_label)))
+            else:
+                reconstructed_edges.add((int(child_label), int(child_label)))
+
+        original_edges = set()
+        for _, row in phylogeny_df.iterrows():
+            original_edges.add((int(row["id"]), int(row["ancestor_id"])))
+
+        assert reconstructed_edges == original_edges
+
+    if with_branch_length:
+        # verify branch lengths are present (not all NaN)
+        assert reconstructed["branch_length"].is_nan().sum() < len(
+            reconstructed
+        )


### PR DESCRIPTION
## Summary
This PR adds functionality to parse phylogenies in Newick format and convert them to alife standard dataframes. Both pandas and polars implementations are provided.

## Key Changes
- **New module `_alifestd_from_newick.py`**: Core Newick parser with two main components:
  - `_parse_newick()`: JIT-compiled numba function that parses Newick format strings into parallel arrays (ids, ancestor_ids, branch_lengths, labels)
  - `_extract_labels()`: Helper function to extract taxon labels from the parsed data
  - `alifestd_from_newick()`: Public API that returns a pandas DataFrame in alife standard format

- **New module `_alifestd_from_newick_polars.py`**: Polars-based wrapper around the core parser that returns a polars DataFrame instead of pandas

- **Comprehensive test suite** (`test_alifestd_from_newick.py` and `test_alifestd_from_newick_polars.py`):
  - Tests for empty input, single nodes, and complex tree structures
  - Branch length parsing (integers, floats, scientific notation, negative values)
  - Quoted and unquoted labels
  - Comment handling (square bracket syntax)
  - Roundtrip testing (alife → newick → alife preserves topology)
  - Asset-based tests with real phylogeny files

## Implementation Details
- The parser is implemented in JIT-compiled numba code for performance, handling:
  - Parentheses for tree structure
  - Colons for branch lengths with full float parsing (including scientific notation)
  - Quoted labels with proper quote stripping
  - Comments in square brackets
  - Whitespace handling
  
- Returns dataframes with columns: `id`, `ancestor_id`, `ancestor_list`, `taxon_label`, `origin_time_delta`, `branch_length`
- Root nodes have `ancestor_id == id` and `ancestor_list == "[none]"`
- Handles edge cases like empty strings and trees with missing branch lengths (NaN values)

https://claude.ai/code/session_013xz3xMEjarQq1qURhnPzXe