### PR TITLE
Seed numba's internal PRNG in RngStateContext and seed_random

### DIFF
--- a/hstrat/_auxiliary_lib/_RngStateContext.py
+++ b/hstrat/_auxiliary_lib/_RngStateContext.py
@@ -3,6 +3,21 @@ from typing import Any
 
 import numpy as np
 
+from ._jit import jit
+
+
+@jit(nopython=True)
+def _seed_jitted(seed: int) -> bool:
+    """Seed numba-internal random state.
+
+    Implementation detail. Numba maintains its own PRNG state separate
+    from Python's random and NumPy's random, so it must be seeded
+    independently from within a jitted function.
+    """
+    np.random.seed(seed)
+    random.seed(seed)
+    return True
+
 
 class RngStateContext:
     """A context manager that temporarily reseeds the `random` module random
@@ -26,6 +41,7 @@ class RngStateContext:
         self._saved_state = random.getstate()
         self._saved_np_state = np.random.get_state()
         random.seed(self.seed)
+        _seed_jitted(self.seed)
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         """Exits the context manager and restores the RNG state to the value

--- a/hstrat/_auxiliary_lib/_RngStateContext.py
+++ b/hstrat/_auxiliary_lib/_RngStateContext.py
@@ -3,20 +3,7 @@ from typing import Any
 
 import numpy as np
 
-from ._jit import jit
-
-
-@jit(nopython=True)
-def _seed_jitted(seed: int) -> bool:
-    """Seed numba-internal random state.
-
-    Implementation detail. Numba maintains its own PRNG state separate
-    from Python's random and NumPy's random, so it must be seeded
-    independently from within a jitted function.
-    """
-    np.random.seed(seed)
-    random.seed(seed)
-    return True
+from ._seed_random import _seed_random_jitted
 
 
 class RngStateContext:
@@ -41,10 +28,18 @@ class RngStateContext:
         self._saved_state = random.getstate()
         self._saved_np_state = np.random.get_state()
         random.seed(self.seed)
-        _seed_jitted(self.seed)
+        _seed_random_jitted(self.seed)
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         """Exits the context manager and restores the RNG state to the value
         saved in _saved_state."""
+        random.setstate(self._saved_state)
+        np.random.set_state(self._saved_np_state)
+        # Reseed jitted PRNG deterministically from the restored state.
+        # Draw seed without consuming from the restored state, and
+        # restore both states after _seed_random_jitted (which may
+        # mutate Python-level state when the jit shim is active).
+        jitted_reseed = random.randint(0, 2**32 - 1)
+        _seed_random_jitted(jitted_reseed)
         random.setstate(self._saved_state)
         np.random.set_state(self._saved_np_state)

--- a/hstrat/_auxiliary_lib/_seed_random.py
+++ b/hstrat/_auxiliary_lib/_seed_random.py
@@ -3,6 +3,21 @@ import random
 import numpy as np
 import polars as pl
 
+from ._jit import jit
+
+
+@jit(nopython=True)
+def _seed_random_jitted(seed: int) -> bool:
+    """Seed numba-internal random state.
+
+    Implementation detail. Numba maintains its own PRNG state separate
+    from Python's random and NumPy's random, so it must be seeded
+    independently from within a jitted function.
+    """
+    np.random.seed(seed)
+    random.seed(seed)
+    return True
+
 
 def seed_random(seed: int) -> bool:
     """Seed all random sources used by hstrat library.
@@ -12,3 +27,4 @@ def seed_random(seed: int) -> bool:
     random.seed(seed)
     np.random.seed(seed)
     pl.set_random_seed(seed)
+    _seed_random_jitted(seed)

--- a/hstrat/_auxiliary_lib/_seed_random.py
+++ b/hstrat/_auxiliary_lib/_seed_random.py
@@ -7,7 +7,7 @@ from ._jit import jit
 
 
 @jit(nopython=True)
-def _seed_random_jitted(seed: int) -> bool:
+def _seed_random_jitted(seed: int) -> None:
     """Seed numba-internal random state.
 
     Implementation detail. Numba maintains its own PRNG state separate
@@ -19,7 +19,7 @@ def _seed_random_jitted(seed: int) -> bool:
     return True
 
 
-def seed_random(seed: int) -> bool:
+def seed_random(seed: int) -> None:
     """Seed all random sources used by hstrat library.
 
     Ensures reproducible execution.

--- a/hstrat/_auxiliary_lib/_seed_random.py
+++ b/hstrat/_auxiliary_lib/_seed_random.py
@@ -16,7 +16,6 @@ def _seed_random_jitted(seed: int) -> None:
     """
     np.random.seed(seed)
     random.seed(seed)
-    return True
 
 
 def seed_random(seed: int) -> None:

--- a/tests/test_hstrat/test_auxiliary_lib/test_RngStateContext.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_RngStateContext.py
@@ -131,25 +131,46 @@ def test_rng_state_context_jitted_nested():
     """Regression test: nested RngStateContext seeds jitted PRNG correctly
     at each level."""
     n = 5
-    outer_seed = 42
     inner_seed = 123
 
-    with RngStateContext(outer_seed):
-        outer_before = _generate_jitted_random_values(n).copy()
-
-    with RngStateContext(outer_seed):
-        _generate_jitted_random_values(n)  # consume same values
-        with RngStateContext(inner_seed):
-            inner_values = _generate_jitted_random_values(n).copy()
-
     # inner context should produce values determined by inner_seed
-    with RngStateContext(inner_seed):
-        inner_expected = _generate_jitted_random_values(n)
+    inner_results = []
+    for _rep in range(3):
+        with RngStateContext(inner_seed):
+            inner_results.append(_generate_jitted_random_values(n))
 
-    np.testing.assert_array_equal(inner_values, inner_expected)
+    for a, b in zip(inner_results, inner_results[1:]):
+        np.testing.assert_array_equal(a, b)
 
-    # outer context should produce values determined by outer_seed
-    with RngStateContext(outer_seed):
-        outer_expected = _generate_jitted_random_values(n)
+    # inner context within outer context should also be deterministic
+    nested_inner_results = []
+    for _rep in range(3):
+        with RngStateContext(42):
+            _generate_jitted_random_values(n)
+            with RngStateContext(inner_seed):
+                nested_inner_results.append(
+                    _generate_jitted_random_values(n),
+                )
 
-    np.testing.assert_array_equal(outer_before, outer_expected)
+    for a, b in zip(nested_inner_results, nested_inner_results[1:]):
+        np.testing.assert_array_equal(a, b)
+
+    # values inside inner context should match regardless of outer context
+    np.testing.assert_array_equal(inner_results[0], nested_inner_results[0])
+
+
+def test_rng_state_context_jitted_exit_deterministic():
+    """Regression test: exiting RngStateContext reseeds jitted PRNG
+    deterministically from the restored random state."""
+    n = 10
+    results_after_exit = []
+    for _rep in range(3):
+        random.seed(99)
+        np.random.seed(99)
+        with RngStateContext(42):
+            _generate_jitted_random_values(5)
+        # after exit, jitted PRNG should be reseeded deterministically
+        results_after_exit.append(_generate_jitted_random_values(n))
+
+    for a, b in zip(results_after_exit, results_after_exit[1:]):
+        np.testing.assert_array_equal(a, b)


### PR DESCRIPTION
## Summary
This PR fixes non-deterministic behavior in jitted code by ensuring numba's internal PRNG is properly seeded and restored alongside Python's `random` and NumPy's `random` modules.

## Key Changes
- Added `_seed_random_jitted()` helper function that seeds numba's PRNG from within a jitted context (required because numba maintains its own separate PRNG state)
- Updated `seed_random()` to call `_seed_random_jitted()` to ensure all random sources are seeded consistently
- Modified `RngStateContext.__enter__()` to seed numba's PRNG when entering the context
- Modified `RngStateContext.__exit__()` to deterministically reseed numba's PRNG when exiting, derived from the restored random state, ensuring reproducibility across nested contexts
- Added comprehensive regression tests for:
  - Deterministic jitted random values within `RngStateContext`
  - Different seeds producing different jitted values
  - Nested `RngStateContext` behavior
  - Deterministic behavior after exiting `RngStateContext`
  - `seed_random()` properly seeding jitted code

## Implementation Details
- Numba's PRNG must be seeded from within a jitted function (`_seed_random_jitted`) because it maintains internal state separate from Python's `random` and NumPy's `random`
- When exiting `RngStateContext`, the jitted PRNG is reseeded using a value drawn from the restored random state, then both states are restored again to maintain determinism
- Tests use a helper function `_generate_jitted_random_values()` decorated with `@jit(nopython=True)` to verify jitted code behavior

https://claude.ai/code/session_01VAP7Ac2DboHoL2MRqqNuMu