### PR TITLE
Release numba <0.64 version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ requires = [
 # additional dev requriements
 # used to generated requirements in dev-requirements/
 [project.optional-dependencies]
-jit = ["cppimport>=22.8.2", "numba>=0.60.0,!=0.62.0,<0.64", "setuptools>=75.0.0,<81"]
+jit = ["cppimport>=22.8.2", "numba>=0.60.0,!=0.62.0", "setuptools>=75.0.0,<81"]
 phylo-extra = [
   "biopython>=1.79",
   "phylotrackpy>=0.2.4",

--- a/requirements-dev/py312/requirements-all.txt
+++ b/requirements-dev/py312/requirements-all.txt
@@ -249,7 +249,7 @@ networkx==3.6.1
     #   alifedata-phyloinformatics-convert
 nh3==0.3.3
     # via readme-renderer
-numba==0.63.1
+numba==0.64.0
     # via hstrat (../../pyproject.toml)
 numpy==2.2.6
     # via

--- a/requirements-dev/py312/requirements-jit.txt
+++ b/requirements-dev/py312/requirements-jit.txt
@@ -104,9 +104,9 @@ networkx==3.6.1
     # via
     #   hstrat (../../pyproject.toml)
     #   alifedata-phyloinformatics-convert
-numba==0.63.1
+numba==0.64.0
     # via hstrat (../../pyproject.toml)
-numpy==2.3.5
+numpy==2.4.2
     # via
     #   hstrat (../../pyproject.toml)
     #   alifedata-phyloinformatics-convert

--- a/requirements-dev/py312/requirements-testing.txt
+++ b/requirements-dev/py312/requirements-testing.txt
@@ -146,7 +146,7 @@ networkx==3.6.1
     # via
     #   hstrat (../../pyproject.toml)
     #   alifedata-phyloinformatics-convert
-numba==0.63.1
+numba==0.64.0
     # via hstrat (../../pyproject.toml)
 numpy==2.2.6
     # via


### PR DESCRIPTION
Remove the upper bound constraint on numba (<0.64) since there is no
incompatibility with numba 0.64. Regenerate requirements-dev files,
which updates py312 to numba 0.64.0.

Closes #309

https://claude.ai/code/session_01LMPynFbbP53PXkhS6Wm8DY