### PR TITLE
Add alifestd_find_pair_mrca_id_asexual and polars variant

### DIFF
--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -526,6 +526,8 @@ __all__ = [
     "alifestd_find_chronological_inconsistency",
     "alifestd_find_leaf_ids",
     "alifestd_find_mrca_id_asexual",
+    "alifestd_find_pair_mrca_id_asexual",
+    "alifestd_find_pair_mrca_id_polars",
     "alifestd_find_root_ids",
     "alifestd_has_compact_ids",
     "alifestd_has_contiguous_ids",

--- a/hstrat/_auxiliary_lib/__init__.pyi
+++ b/hstrat/_auxiliary_lib/__init__.pyi
@@ -127,6 +127,12 @@ from ._alifestd_find_chronological_inconsistency import (
 )
 from ._alifestd_find_leaf_ids import alifestd_find_leaf_ids
 from ._alifestd_find_mrca_id_asexual import alifestd_find_mrca_id_asexual
+from ._alifestd_find_pair_mrca_id_asexual import (
+    alifestd_find_pair_mrca_id_asexual,
+)
+from ._alifestd_find_pair_mrca_id_polars import (
+    alifestd_find_pair_mrca_id_polars,
+)
 from ._alifestd_find_root_ids import alifestd_find_root_ids
 from ._alifestd_has_compact_ids import alifestd_has_compact_ids
 from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids

--- a/hstrat/_auxiliary_lib/_alifestd_find_pair_mrca_id_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_find_pair_mrca_id_asexual.py
@@ -36,35 +36,17 @@ def _alifestd_find_pair_mrca_id_asexual_fast_path(
         The id of the most recent common ancestor, or -1 if no common
         ancestor exists.
     """
-    ancestor_ids = ancestor_ids.astype(np.uint64)
-    # walk both lineages towards the root, always advancing the deeper
-    # (higher-id) node first; when both reach the same node, that is
-    # the MRCA
-    a = first
-    b = second
+    # walk both lineages towards the root
+    # by advancing the deeper (higher-id) node first
+    a, b = first, second
     while a != b:
-        if a > b:
-            next_a = ancestor_ids[a]
-            if next_a == a:
-                # a is a root; walk b up to see if it reaches a
-                while b != a:
-                    next_b = ancestor_ids[b]
-                    if next_b == b:
-                        return -1  # b is also a root, disjoint trees
-                    b = next_b
-                return a
-            a = next_a
-        else:
-            next_b = ancestor_ids[b]
-            if next_b == b:
-                # b is a root; walk a up to see if it reaches b
-                while a != b:
-                    next_a = ancestor_ids[a]
-                    if next_a == a:
-                        return -1  # a is also a root, disjoint trees
-                    a = next_a
-                return b
-            b = next_b
+        a, b = min(a, b), max(a, b)
+        next_b = ancestor_ids[b]
+        if next_b == b:
+            assert a != b
+            return -1  # b is a root, disjoint trees
+        b = next_b
+    assert a == b
     return a
 
 
@@ -123,12 +105,12 @@ def alifestd_find_pair_mrca_id_asexual(
         has_contiguous_ids,
         lambda: alifestd_has_contiguous_ids(phylogeny_df),
     ):
-        raise NotImplementedError(
-            "non-contiguous ids not yet supported",
-        )
+        raise NotImplementedError("non-contiguous ids not yet supported")
 
     ancestor_ids = phylogeny_df["ancestor_id"].to_numpy()
     result = _alifestd_find_pair_mrca_id_asexual_fast_path(
-        ancestor_ids, first, second,
+        ancestor_ids,
+        first,
+        second,
     )
     return None if result == -1 else int(result)

--- a/hstrat/_auxiliary_lib/_alifestd_find_pair_mrca_id_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_find_pair_mrca_id_asexual.py
@@ -1,0 +1,130 @@
+import typing
+
+import numpy as np
+import opytional as opyt
+import pandas as pd
+
+from ._alifestd_has_contiguous_ids import alifestd_has_contiguous_ids
+from ._alifestd_is_topologically_sorted import alifestd_is_topologically_sorted
+from ._alifestd_try_add_ancestor_id_col import alifestd_try_add_ancestor_id_col
+from ._jit import jit
+
+
+@jit(nopython=True)
+def _find_pair_mrca_id_asexual_contiguous(
+    ancestor_ids: np.ndarray,
+    first: int,
+    second: int,
+) -> int:
+    """Find the MRCA of two taxa in a contiguous, topologically sorted
+    asexual phylogeny.
+
+    Parameters
+    ----------
+    ancestor_ids : np.ndarray
+        Array of ancestor ids, where index corresponds to taxon id.
+
+        Must be topologically sorted with contiguous ids.
+    first : int
+        First taxon id.
+    second : int
+        Second taxon id.
+
+    Returns
+    -------
+    int
+        The id of the most recent common ancestor, or -1 if no common
+        ancestor exists.
+    """
+    ancestor_ids = ancestor_ids.astype(np.uint64)
+    # walk both lineages towards the root, always advancing the deeper
+    # (higher-id) node first; when both reach the same node, that is
+    # the MRCA
+    a = first
+    b = second
+    while a != b:
+        if a > b:
+            next_a = ancestor_ids[a]
+            if next_a == a:
+                # a is a root; walk b up to see if it reaches a
+                while b != a:
+                    next_b = ancestor_ids[b]
+                    if next_b == b:
+                        return -1  # b is also a root, disjoint trees
+                    b = next_b
+                return a
+            a = next_a
+        else:
+            next_b = ancestor_ids[b]
+            if next_b == b:
+                # b is a root; walk a up to see if it reaches b
+                while a != b:
+                    next_a = ancestor_ids[a]
+                    if next_a == a:
+                        return -1  # a is also a root, disjoint trees
+                    a = next_a
+                return b
+            b = next_b
+    return a
+
+
+def alifestd_find_pair_mrca_id_asexual(
+    phylogeny_df: pd.DataFrame,
+    first: int,
+    second: int,
+    *,
+    mutate: bool = False,
+    is_topologically_sorted: typing.Optional[bool] = None,
+    has_contiguous_ids: typing.Optional[bool] = None,
+) -> typing.Optional[int]:
+    """Find the Most Recent Common Ancestor of two taxa.
+
+    Parameters
+    ----------
+    phylogeny_df : pd.DataFrame
+        Phylogeny in alife standard format.
+    first : int
+        First taxon id.
+    second : int
+        Second taxon id.
+    mutate : bool, default False
+        If True, allows in-place modification of `phylogeny_df`.
+    is_topologically_sorted : bool, optional
+        If provided, skips the topological sort check. If None
+        (default), the check is performed automatically.
+    has_contiguous_ids : bool, optional
+        If provided, skips the contiguous ids check. If None (default),
+        the check is performed automatically.
+
+    Returns
+    -------
+    int or None
+        The id of the most recent common ancestor, or None if no common
+        ancestor exists.
+    """
+    if not mutate:
+        phylogeny_df = phylogeny_df.copy()
+
+    phylogeny_df = alifestd_try_add_ancestor_id_col(phylogeny_df, mutate=True)
+
+    if not opyt.or_value(
+        is_topologically_sorted,
+        alifestd_is_topologically_sorted(phylogeny_df),
+    ):
+        raise NotImplementedError(
+            "topologically unsorted rows not yet supported",
+        )
+
+    if not opyt.or_value(
+        has_contiguous_ids,
+        alifestd_has_contiguous_ids(phylogeny_df),
+    ):
+        raise NotImplementedError(
+            "non-contiguous ids not yet supported",
+        )
+
+    ancestor_ids = phylogeny_df["ancestor_id"].to_numpy()
+    result = _find_pair_mrca_id_asexual_contiguous(ancestor_ids, first, second)
+    if result == -1:
+        return None
+    return int(result)

--- a/hstrat/_auxiliary_lib/_alifestd_find_pair_mrca_id_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_find_pair_mrca_id_polars.py
@@ -83,6 +83,8 @@ def alifestd_find_pair_mrca_id_polars(
     )
 
     result = _alifestd_find_pair_mrca_id_asexual_fast_path(
-        ancestor_ids, first, second,
+        ancestor_ids,
+        first,
+        second,
     )
     return None if result == -1 else int(result)

--- a/hstrat/_auxiliary_lib/_alifestd_find_pair_mrca_id_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_find_pair_mrca_id_polars.py
@@ -1,0 +1,88 @@
+import typing
+
+import opytional as opyt
+import polars as pl
+
+from ._alifestd_find_pair_mrca_id_asexual import (
+    _find_pair_mrca_id_asexual_contiguous,
+)
+from ._alifestd_has_contiguous_ids_polars import (
+    alifestd_has_contiguous_ids_polars,
+)
+from ._alifestd_is_topologically_sorted_polars import (
+    alifestd_is_topologically_sorted_polars,
+)
+from ._alifestd_try_add_ancestor_id_col_polars import (
+    alifestd_try_add_ancestor_id_col_polars,
+)
+
+
+def alifestd_find_pair_mrca_id_polars(
+    phylogeny_df: pl.DataFrame,
+    first: int,
+    second: int,
+    *,
+    is_topologically_sorted: typing.Optional[bool] = None,
+    has_contiguous_ids: typing.Optional[bool] = None,
+) -> typing.Optional[int]:
+    """Find the Most Recent Common Ancestor of two taxa.
+
+    Parameters
+    ----------
+    phylogeny_df : polars.DataFrame or polars.LazyFrame
+        The phylogeny as a dataframe in alife standard format.
+
+        Must represent an asexual phylogeny with contiguous ids and
+        topologically sorted rows.
+    first : int
+        First taxon id.
+    second : int
+        Second taxon id.
+    is_topologically_sorted : bool, optional
+        If provided, skips the topological sort check. If None
+        (default), the check is performed automatically.
+    has_contiguous_ids : bool, optional
+        If provided, skips the contiguous ids check. If None (default),
+        the check is performed automatically.
+
+    Returns
+    -------
+    int or None
+        The id of the most recent common ancestor, or None if no common
+        ancestor exists.
+
+    See Also
+    --------
+    alifestd_find_pair_mrca_id_asexual :
+        Pandas-based implementation.
+    """
+    phylogeny_df = alifestd_try_add_ancestor_id_col_polars(phylogeny_df)
+
+    if not opyt.or_value(
+        has_contiguous_ids,
+        alifestd_has_contiguous_ids_polars(phylogeny_df),
+    ):
+        raise NotImplementedError(
+            "non-contiguous ids not yet supported",
+        )
+
+    if not opyt.or_value(
+        is_topologically_sorted,
+        alifestd_is_topologically_sorted_polars(phylogeny_df),
+    ):
+        raise NotImplementedError(
+            "topologically unsorted rows not yet supported",
+        )
+
+    ancestor_ids = (
+        phylogeny_df.lazy()
+        .select("ancestor_id")
+        .collect()
+        .to_series()
+        .to_numpy()
+    )
+
+    result = _find_pair_mrca_id_asexual_contiguous(ancestor_ids, first, second)
+    if result == -1:
+        return None
+    return int(result)

--- a/hstrat/_auxiliary_lib/_alifestd_find_pair_mrca_id_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_find_pair_mrca_id_polars.py
@@ -4,7 +4,7 @@ import opytional as opyt
 import polars as pl
 
 from ._alifestd_find_pair_mrca_id_asexual import (
-    _find_pair_mrca_id_asexual_contiguous,
+    _alifestd_find_pair_mrca_id_asexual_fast_path,
 )
 from ._alifestd_has_contiguous_ids_polars import (
     alifestd_has_contiguous_ids_polars,
@@ -58,17 +58,17 @@ def alifestd_find_pair_mrca_id_polars(
     """
     phylogeny_df = alifestd_try_add_ancestor_id_col_polars(phylogeny_df)
 
-    if not opyt.or_value(
+    if not opyt.or_else(
         has_contiguous_ids,
-        alifestd_has_contiguous_ids_polars(phylogeny_df),
+        lambda: alifestd_has_contiguous_ids_polars(phylogeny_df),
     ):
         raise NotImplementedError(
             "non-contiguous ids not yet supported",
         )
 
-    if not opyt.or_value(
+    if not opyt.or_else(
         is_topologically_sorted,
-        alifestd_is_topologically_sorted_polars(phylogeny_df),
+        lambda: alifestd_is_topologically_sorted_polars(phylogeny_df),
     ):
         raise NotImplementedError(
             "topologically unsorted rows not yet supported",
@@ -82,7 +82,7 @@ def alifestd_find_pair_mrca_id_polars(
         .to_numpy()
     )
 
-    result = _find_pair_mrca_id_asexual_contiguous(ancestor_ids, first, second)
-    if result == -1:
-        return None
-    return int(result)
+    result = _alifestd_find_pair_mrca_id_asexual_fast_path(
+        ancestor_ids, first, second,
+    )
+    return None if result == -1 else int(result)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_find_pair_mrca_id_asexual.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_find_pair_mrca_id_asexual.py
@@ -1,0 +1,183 @@
+import os
+
+import pandas as pd
+import pytest
+
+from hstrat._auxiliary_lib import (
+    alifestd_find_mrca_id_asexual,
+    alifestd_to_working_format,
+)
+from hstrat._auxiliary_lib._alifestd_find_pair_mrca_id_asexual import (
+    alifestd_find_pair_mrca_id_asexual,
+)
+
+assets_path = os.path.join(os.path.dirname(__file__), "assets")
+
+
+@pytest.mark.parametrize(
+    "phylogeny_df",
+    [
+        alifestd_to_working_format(
+            pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv")
+        ),
+        alifestd_to_working_format(
+            pd.read_csv(f"{assets_path}/nk_lexicaseselection.csv")
+        ),
+        alifestd_to_working_format(
+            pd.read_csv(f"{assets_path}/nk_tournamentselection.csv")
+        ),
+    ],
+)
+def test_fuzz_matches_existing(phylogeny_df: pd.DataFrame):
+    """Verify pair mrca matches the multi-id mrca function on real data."""
+    ids = phylogeny_df["id"].tolist()
+    for i in ids[:5]:
+        for j in ids[:5]:
+            expected = alifestd_find_mrca_id_asexual(
+                phylogeny_df, [i, j], mutate=False
+            )
+            actual = alifestd_find_pair_mrca_id_asexual(
+                phylogeny_df, i, j, mutate=False
+            )
+            assert actual == expected
+
+
+@pytest.mark.parametrize("mutate", [True, False])
+def test_simple1(mutate: bool):
+    # Tree:  0 -> 1 -> 2, 0 -> 3
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2, 3],
+            "ancestor_id": [0, 0, 1, 0],
+        }
+    )
+    original_df = phylogeny_df.copy()
+
+    assert (
+        alifestd_find_pair_mrca_id_asexual(phylogeny_df, 0, 1, mutate=mutate)
+        == 0
+    )
+    assert (
+        alifestd_find_pair_mrca_id_asexual(phylogeny_df, 1, 2, mutate=mutate)
+        == 1
+    )
+    assert (
+        alifestd_find_pair_mrca_id_asexual(phylogeny_df, 2, 3, mutate=mutate)
+        == 0
+    )
+    assert (
+        alifestd_find_pair_mrca_id_asexual(phylogeny_df, 2, 2, mutate=mutate)
+        == 2
+    )
+    assert (
+        alifestd_find_pair_mrca_id_asexual(phylogeny_df, 0, 0, mutate=mutate)
+        == 0
+    )
+
+    if not mutate:
+        assert original_df.equals(phylogeny_df)
+
+
+def test_simple_with_ancestor_list():
+    phylogeny_df = alifestd_to_working_format(
+        pd.DataFrame(
+            {
+                "id": [0, 1, 2, 3],
+                "ancestor_list": ["[None]", "[0]", "[1]", "[0]"],
+            }
+        )
+    )
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 2, 3) == 0
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 1, 2) == 1
+
+
+def test_single_node():
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0],
+            "ancestor_id": [0],
+        }
+    )
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 0, 0) == 0
+
+
+def test_multiple_roots_disjoint():
+    """Two disjoint roots should return None."""
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2],
+            "ancestor_id": [0, 1, 2],
+        }
+    )
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 0, 1) is None
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 1, 2) is None
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 0, 0) == 0
+
+
+def test_multiple_roots_partial():
+    """Forest: tree1 = {0, 1}, tree2 = {2, 3}."""
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2, 3],
+            "ancestor_id": [0, 0, 2, 2],
+        }
+    )
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 0, 1) == 0
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 2, 3) == 2
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 0, 2) is None
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 1, 3) is None
+
+
+def test_chain():
+    """Straight chain: 0 -> 1 -> 2 -> 3."""
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2, 3],
+            "ancestor_id": [0, 0, 1, 2],
+        }
+    )
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 0, 3) == 0
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 1, 3) == 1
+    assert alifestd_find_pair_mrca_id_asexual(phylogeny_df, 2, 3) == 2
+
+
+def test_bypass_kwargs():
+    """Test that is_topologically_sorted and has_contiguous_ids kwargs work."""
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2, 3],
+            "ancestor_id": [0, 0, 1, 0],
+        }
+    )
+    result = alifestd_find_pair_mrca_id_asexual(
+        phylogeny_df,
+        2,
+        3,
+        is_topologically_sorted=True,
+        has_contiguous_ids=True,
+    )
+    assert result == 0
+
+
+def test_not_topologically_sorted_raises():
+    """Should raise NotImplementedError for unsorted input."""
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [3, 2, 1, 0],
+            "ancestor_id": [2, 0, 0, 0],
+        }
+    )
+    with pytest.raises(NotImplementedError):
+        alifestd_find_pair_mrca_id_asexual(phylogeny_df, 0, 3)
+
+
+def test_non_contiguous_ids_raises():
+    """Should raise NotImplementedError for non-contiguous ids."""
+    phylogeny_df = pd.DataFrame(
+        {
+            "id": [0, 2, 4],
+            "ancestor_id": [0, 0, 2],
+        }
+    )
+    with pytest.raises(NotImplementedError):
+        alifestd_find_pair_mrca_id_asexual(phylogeny_df, 0, 4)

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_find_pair_mrca_id_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_find_pair_mrca_id_polars.py
@@ -1,0 +1,236 @@
+import os
+import typing
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from hstrat._auxiliary_lib import alifestd_to_working_format
+from hstrat._auxiliary_lib._alifestd_find_pair_mrca_id_asexual import (
+    alifestd_find_pair_mrca_id_asexual,
+)
+from hstrat._auxiliary_lib._alifestd_find_pair_mrca_id_polars import (
+    alifestd_find_pair_mrca_id_polars,
+)
+
+assets_path = os.path.join(os.path.dirname(__file__), "assets")
+
+
+@pytest.mark.parametrize(
+    "phylogeny_df",
+    [
+        alifestd_to_working_format(
+            pd.read_csv(f"{assets_path}/nk_ecoeaselection.csv")
+        ),
+        alifestd_to_working_format(
+            pd.read_csv(f"{assets_path}/nk_lexicaseselection.csv")
+        ),
+        alifestd_to_working_format(
+            pd.read_csv(f"{assets_path}/nk_tournamentselection.csv")
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_fuzz_matches_pandas(
+    phylogeny_df: pd.DataFrame, apply: typing.Callable
+):
+    """Verify polars pair mrca matches pandas implementation on real data."""
+    df_pl = pl.from_pandas(phylogeny_df)
+    ids = phylogeny_df["id"].tolist()
+    for i in ids[:5]:
+        for j in ids[:5]:
+            expected = alifestd_find_pair_mrca_id_asexual(
+                phylogeny_df, i, j, mutate=False
+            )
+            actual = alifestd_find_pair_mrca_id_polars(apply(df_pl), i, j)
+            assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_simple1(apply: typing.Callable):
+    """Test a simple 4-node tree: 0 -> 1 -> 2, 0 -> 3."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [0, 1, 2, 3],
+                "ancestor_id": [0, 0, 1, 0],
+            }
+        )
+    )
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 0, 1) == 0
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 1, 2) == 1
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 2, 3) == 0
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 2, 2) == 2
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 0, 0) == 0
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_single_node(apply: typing.Callable):
+    """A single root node: MRCA with self is self."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [0],
+                "ancestor_id": [0],
+            }
+        )
+    )
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 0, 0) == 0
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_multiple_roots_disjoint(apply: typing.Callable):
+    """Two disjoint roots should return None."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [0, 1, 2],
+                "ancestor_id": [0, 1, 2],
+            }
+        )
+    )
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 0, 1) is None
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 1, 2) is None
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 0, 0) == 0
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_multiple_roots_partial(apply: typing.Callable):
+    """Forest: tree1 = {0, 1}, tree2 = {2, 3}."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [0, 1, 2, 3],
+                "ancestor_id": [0, 0, 2, 2],
+            }
+        )
+    )
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 0, 1) == 0
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 2, 3) == 2
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 0, 2) is None
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 1, 3) is None
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_chain(apply: typing.Callable):
+    """Straight chain: 0 -> 1 -> 2 -> 3."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [0, 1, 2, 3],
+                "ancestor_id": [0, 0, 1, 2],
+            }
+        )
+    )
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 0, 3) == 0
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 1, 3) == 1
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 2, 3) == 2
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_with_ancestor_list_col(apply: typing.Callable):
+    """Test that ancestor_list is correctly converted to ancestor_id."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [0, 1, 2, 3],
+                "ancestor_list": ["[None]", "[0]", "[0]", "[1]"],
+            }
+        )
+    )
+    # Tree: 0->1->3, 0->2
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 2, 3) == 0
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 1, 3) == 1
+    assert alifestd_find_pair_mrca_id_polars(df_pl, 1, 2) == 0
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_does_not_mutate_input(apply: typing.Callable):
+    """Verify the input dataframe is not mutated."""
+    df_pl = pl.DataFrame(
+        {
+            "id": [0, 1, 2, 3],
+            "ancestor_id": [0, 0, 1, 0],
+        }
+    )
+    original_data = df_pl.clone()
+
+    alifestd_find_pair_mrca_id_polars(apply(df_pl), 1, 2)
+
+    assert df_pl.columns == original_data.columns
+    assert df_pl.equals(original_data)
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
+def test_bypass_kwargs(apply: typing.Callable):
+    """Test that is_topologically_sorted and has_contiguous_ids kwargs work."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": [0, 1, 2, 3],
+                "ancestor_id": [0, 0, 1, 0],
+            }
+        )
+    )
+    result = alifestd_find_pair_mrca_id_polars(
+        df_pl,
+        2,
+        3,
+        is_topologically_sorted=True,
+        has_contiguous_ids=True,
+    )
+    assert result == 0


### PR DESCRIPTION
Implement efficient pairwise MRCA lookup for asexual phylogenies:
- _find_pair_mrca_id_asexual_contiguous: jitted helper that walks both
  lineages toward the root, returning -1 for disjoint trees
- alifestd_find_pair_mrca_id_asexual: pandas interface with
  is_topologically_sorted/has_contiguous_ids bypass kwargs
- alifestd_find_pair_mrca_id_polars: polars interface supporting both
  eager and lazy DataFrames, collecting only the ancestor_id column

Both functions return None when no common ancestor exists.

https://claude.ai/code/session_01J5xGLUgiA59jKigDEfV3Rx