### PR TITLE
Upgrade CI Python version from 3.10 to 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,17 +202,17 @@ jobs:
           - "test_test_drive"
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo apt-get update -o Acquire::Retries=3
         sudo apt-get install -y ffmpeg -o Acquire::Retries=3
         python -m pip install --upgrade pip setuptools
-        python -m pip install -r requirements-dev/py310/requirements-testing.txt
+        python -m pip install -r requirements-dev/py312/requirements-testing.txt
     - name: Log coverage configuration
       run: coverage debug sys
     - name: Run tests with coverage report


### PR DESCRIPTION
## Summary
Updated the CI/CD pipeline to use Python 3.12 instead of Python 3.10 for running tests.

## Changes
- Updated GitHub Actions workflow to set up Python 3.12
- Updated test dependencies to use the Python 3.12 requirements file (`requirements-dev/py312/requirements-testing.txt`)

## Details
This change modernizes the CI environment to test against a more recent Python version, ensuring compatibility with Python 3.12 and allowing the project to benefit from the latest language features and performance improvements.

https://claude.ai/code/session_016atJvXVg2ofvzKbuinB8Xq