### PR TITLE
Optimize alifestd_mark_num_children_asexual with vectorized operations

### DIFF
--- a/hstrat/_auxiliary_lib/_alifestd_mark_num_children_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_mark_num_children_asexual.py
@@ -15,24 +15,15 @@ from ._configure_prod_logging import configure_prod_logging
 from ._delegate_polars_implementation import delegate_polars_implementation
 from ._format_cli_description import format_cli_description
 from ._get_hstrat_version import get_hstrat_version
-from ._jit import jit
 from ._log_context_duration import log_context_duration
 
 
-@jit(nopython=True)
 def _alifestd_mark_num_children_asexual_fast_path(
     ancestor_ids: np.ndarray,
 ) -> np.ndarray:
     """Implementation detail for `alifestd_mark_num_children_asexual`."""
-
-    num_children = np.zeros_like(ancestor_ids)
-    for idx_r, ancestor_id in enumerate(ancestor_ids[::-1]):
-        idx = len(ancestor_ids) - 1 - idx_r
-        if ancestor_id == idx:
-            continue  # handle genesis cases
-
-        num_children[ancestor_id] += 1
-
+    num_children = np.bincount(ancestor_ids, minlength=len(ancestor_ids))
+    num_children -= ancestor_ids == np.arange(len(ancestor_ids))
     return num_children
 
 


### PR DESCRIPTION
## Summary
Refactored the `_alifestd_mark_num_children_asexual_fast_path` function to use vectorized NumPy operations instead of explicit loops, improving performance and removing unnecessary JIT compilation.

## Key Changes
- Replaced manual loop-based counting with `np.bincount()` for efficient histogram computation
- Removed `@jit(nopython=True)` decorator and corresponding import, as vectorized NumPy operations are already optimized
- Simplified genesis case handling using vectorized boolean indexing instead of conditional logic
- Reduced code complexity from 10 lines to 2 lines while maintaining identical functionality

## Implementation Details
The new implementation leverages NumPy's built-in `bincount()` function which is highly optimized for counting occurrences. The genesis case (where `ancestor_id == idx`) is now handled through vectorized subtraction: `num_children -= ancestor_ids == np.arange(len(ancestor_ids))`, which subtracts 1 from counts where an organism is its own ancestor.

https://claude.ai/code/session_01PxkBMLeXQPFZuAeCGp6Cm9