### PR TITLE
Fix argparse prefix matching of --drop to --drop-dstream-metadata

### DIFF
--- a/hstrat/dataframe/surface_build_tree.py
+++ b/hstrat/dataframe/surface_build_tree.py
@@ -105,6 +105,7 @@ See Also
 def _create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         add_help=False,
+        allow_abbrev=False,
         description=format_cli_description(raw_message),
         formatter_class=argparse.RawTextHelpFormatter,
     )

--- a/hstrat/dataframe/surface_postprocess_trie.py
+++ b/hstrat/dataframe/surface_postprocess_trie.py
@@ -108,6 +108,7 @@ Behind the scenes, the following postprocessing steps occur:
 def _create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         add_help=False,
+        allow_abbrev=False,
         description=format_cli_description(raw_message),
         formatter_class=argparse.RawTextHelpFormatter,
     )

--- a/hstrat/dataframe/surface_test_drive.py
+++ b/hstrat/dataframe/surface_test_drive.py
@@ -85,6 +85,7 @@ pl.DataFrame
 def _create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         add_help=False,
+        allow_abbrev=False,
         description=format_cli_description(raw_message),
         formatter_class=argparse.RawTextHelpFormatter,
     )

--- a/hstrat/dataframe/surface_unpack_reconstruct.py
+++ b/hstrat/dataframe/surface_unpack_reconstruct.py
@@ -142,6 +142,7 @@ Environment variables POLARS_MAX_THREADS and NUMBA_NUM_THREADS may be used to tu
 def _create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         add_help=False,
+        allow_abbrev=False,
         description=format_cli_description(raw_message),
         formatter_class=argparse.RawTextHelpFormatter,
     )

--- a/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct.py
+++ b/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct.py
@@ -10,6 +10,7 @@ from hstrat._auxiliary_lib import (
     alifestd_validate,
 )
 from hstrat.dataframe import surface_unpack_reconstruct
+from hstrat.dataframe.surface_unpack_reconstruct import _create_parser
 
 assets_path = os.path.join(os.path.dirname(__file__), "assets")
 
@@ -47,6 +48,30 @@ def test_drop_dstream_metadata_true_raises():
     df = pl.read_csv(f"{assets_path}/packed.csv")
     with pytest.raises(NotImplementedError):
         surface_unpack_reconstruct(df, drop_dstream_metadata=True)
+
+
+def test_parser_no_prefix_matching_drop():
+    """Regression: --drop must not prefix-match --drop-dstream-metadata.
+
+    The parser uses parse_known_args before joinem registers --drop.
+    Without allow_abbrev=False, argparse prefix-matches --drop to
+    --drop-dstream-metadata, causing conflicts when both --drop and
+    --no-drop-dstream-metadata appear on the same command line.
+    """
+    parser = _create_parser()
+    # --drop is not registered on this parser (joinem adds it later),
+    # so it should pass through as an unknown arg
+    args, remaining = parser.parse_known_args(
+        [
+            "--no-drop-dstream-metadata",
+            "--drop",
+            "awoo",
+            "/dev/null",
+        ],
+    )
+    assert args.drop_dstream_metadata is False
+    assert "--drop" in remaining
+    assert "awoo" in remaining
 
 
 def test_drop_dstream_metadata_false():

--- a/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct_cli.py
+++ b/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct_cli.py
@@ -89,6 +89,41 @@ def test_surface_unpack_reconstruct_cli_no_drop_dstream_metadata():
     assert len(dstream_cols) > 2
 
 
+def test_surface_unpack_reconstruct_cli_drop_with_no_drop_dstream_metadata():
+    """Regression: --drop must not prefix-match --drop-dstream-metadata.
+
+    Before allow_abbrev=False, argparse would prefix-match the joinem
+    --drop flag to the hstrat --drop-dstream-metadata flag when
+    parse_known_args was called (before joinem registered --drop).
+    This caused a conflict with --no-drop-dstream-metadata on the same
+    command line.
+    """
+    output_file = (
+        "/tmp/hstrat_unpack_surface_reconstruct_drop_col.pqt"  # nosec B108
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    result = subprocess.run(
+        [
+            "python3",
+            "-m",
+            "hstrat.dataframe.surface_unpack_reconstruct",
+            output_file,
+            "--no-drop-dstream-metadata",
+            "--drop",
+            "awoo",
+        ],
+        check=True,
+        input=f"{assets}/packed.csv".encode(),
+    )
+    assert result.returncode == 0
+    assert os.path.exists(output_file)
+    res = pl.read_parquet(output_file)
+    assert "awoo" not in res.columns
+    dstream_cols = [c for c in res.columns if c.startswith("dstream_")]
+    # --no-drop-dstream-metadata should retain dstream metadata columns
+    assert len(dstream_cols) > 2
+
+
 def test_surface_unpack_reconstruct_cli_drop_dstream_metadata_fails():
     output_file = (
         "/tmp/hstrat_unpack_surface_reconstruct_drop.pqt"  # nosec B108


### PR DESCRIPTION
Add allow_abbrev=False to ArgumentParser in all four dataframe CLI
modules. Without this, argparse prefix-matches the joinem --drop flag
to --drop-dstream-metadata during parse_known_args (before joinem
registers --drop), causing a conflict when --no-drop-dstream-metadata
is also present on the command line.

Add regression tests for this edge case in both unit and CLI test files.

https://claude.ai/code/session_01PAEYkCUTkpur1RXE7P4Eef