### PR TITLE
Fix numba TypingError from UInt64 ancestor_id in MRCA calc

### DIFF
--- a/hstrat/_auxiliary_lib/_alifestd_calc_mrca_id_vector_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_calc_mrca_id_vector_asexual.py
@@ -77,7 +77,7 @@ def alifestd_calc_mrca_id_vector_asexual(
     if target_id >= len(phylogeny_df):
         raise ValueError(f"{target_id=} out of bounds")
 
-    ancestor_ids = phylogeny_df["ancestor_id"].to_numpy()
+    ancestor_ids = phylogeny_df["ancestor_id"].to_numpy().astype(np.int64)
     assert np.all(
         phylogeny_df["id"].to_numpy() == np.arange(len(phylogeny_df))
     )

--- a/hstrat/_auxiliary_lib/_alifestd_calc_mrca_id_vector_asexual_polars.py
+++ b/hstrat/_auxiliary_lib/_alifestd_calc_mrca_id_vector_asexual_polars.py
@@ -85,7 +85,7 @@ def alifestd_calc_mrca_id_vector_asexual_polars(
     )
     ancestor_ids = (
         phylogeny_df.lazy()
-        .select("ancestor_id")
+        .select(pl.col("ancestor_id").cast(pl.Int64))
         .collect()
         .to_series()
         .to_numpy()

--- a/tests/test_hstrat/test_auxiliary_lib/test_alifestd_calc_mrca_id_vector_asexual_polars.py
+++ b/tests/test_hstrat/test_auxiliary_lib/test_alifestd_calc_mrca_id_vector_asexual_polars.py
@@ -353,6 +353,29 @@ def test_multiple_roots(apply: typing.Callable):
         pytest.param(lambda x: x.lazy(), id="LazyFrame"),
     ],
 )
+def test_uint64_ancestor_id(apply: typing.Callable):
+    """Regression: UInt64 ancestor_id caused numba float64 type unification."""
+    df_pl = apply(
+        pl.DataFrame(
+            {
+                "id": pl.Series([0, 1, 2, 3], dtype=pl.UInt64),
+                "ancestor_id": pl.Series([0, 0, 1, 0], dtype=pl.UInt64),
+            }
+        )
+    )
+    result = alifestd_calc_mrca_id_vector_asexual_polars(df_pl, target_id=2)
+    np.testing.assert_array_equal(
+        result, np.array([0, 1, 2, 0], dtype=np.int64)
+    )
+
+
+@pytest.mark.parametrize(
+    "apply",
+    [
+        pytest.param(lambda x: x, id="DataFrame"),
+        pytest.param(lambda x: x.lazy(), id="LazyFrame"),
+    ],
+)
 def test_with_ancestor_list_col(apply: typing.Callable):
     """Test that ancestor_list is correctly converted to ancestor_id."""
     df_pl = apply(


### PR DESCRIPTION
When ancestor_id column is polars UInt64, numba unifies int64 (target_id)
and uint64 (array values) into float64, causing a setitem type error.
Cast ancestor_id to Int64 before passing to the numba-jitted function.

https://claude.ai/code/session_018drTsfUVNovw1fLpNaBbXH