### PR TITLE
Block default Docker entrypoint with error message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,3 +40,5 @@ RUN python3 -m hstrat.dataframe.surface_unpack_reconstruct --help
 # Clean up
 RUN apt-get clean \
     && rm -rf /root/.cache /tmp/* /app
+
+ENTRYPOINT echo "Error:  no default entrypoint; use 'singularity exec python3 -m hstrat' instead of 'singularity run'." >&2; exit 1


### PR DESCRIPTION
Direct users to use 'singularity exec python3 -m hstrat' instead of
'singularity run' by setting an ENTRYPOINT that prints an error and
exits with status 1.

https://claude.ai/code/session_01CMLuZQcygfGxf8kAY3QRrH