### PR TITLE
Fix np.bincount dtype compatibility issues

### DIFF
--- a/hstrat/_auxiliary_lib/_alifestd_downsample_tips_canopy_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_downsample_tips_canopy_asexual.py
@@ -102,7 +102,7 @@ def alifestd_downsample_tips_canopy_asexual(
             num_tips = int((leaf_df[criterion] == max_val).sum())
         kept_ids = leaf_df.nlargest(num_tips, criterion)["id"]
         phylogeny_df["extant"] = np.bincount(
-            kept_ids.to_numpy(), minlength=len(phylogeny_df)
+            kept_ids.to_numpy().astype(np.intp), minlength=len(phylogeny_df)
         ).astype(bool)
     else:
         tips = alifestd_find_leaf_ids(phylogeny_df)

--- a/hstrat/_auxiliary_lib/_alifestd_mark_num_children_asexual.py
+++ b/hstrat/_auxiliary_lib/_alifestd_mark_num_children_asexual.py
@@ -22,7 +22,9 @@ def _alifestd_mark_num_children_asexual_fast_path(
     ancestor_ids: np.ndarray,
 ) -> np.ndarray:
     """Implementation detail for `alifestd_mark_num_children_asexual`."""
-    num_children = np.bincount(ancestor_ids, minlength=len(ancestor_ids))
+    num_children = np.bincount(
+        ancestor_ids.astype(np.intp), minlength=len(ancestor_ids)
+    )
     num_children -= ancestor_ids == np.arange(len(ancestor_ids))
     return num_children
 


### PR DESCRIPTION
## Summary
Fixed dtype compatibility issues with `np.bincount()` by explicitly casting input arrays to `np.intp` type, ensuring consistent behavior across different platforms and NumPy versions.

## Key Changes
- **`_alifestd_mark_num_children_asexual.py`**: Cast `ancestor_ids` to `np.intp` before passing to `np.bincount()`
- **`_alifestd_downsample_tips_canopy_asexual.py`**: Cast `kept_ids.to_numpy()` to `np.intp` before passing to `np.bincount()`

## Implementation Details
`np.bincount()` requires its input array to have an integer dtype compatible with platform indexing. By explicitly converting to `np.intp` (which is the native integer type used for indexing), we ensure the function works correctly regardless of the input array's original dtype or the target platform's architecture.

https://claude.ai/code/session_01SvBQ2CEuTY5FKobdo8o7ms