### PR TITLE
Add exploded-slice-size parameter to surface reconstruction examples

### DIFF
--- a/examples/end2end_tree_reconstruction_with_dstream_surf.sh
+++ b/examples/end2end_tree_reconstruction_with_dstream_surf.sh
@@ -25,6 +25,7 @@ reconst_phylo_df_path="/tmp/end2end-reconst-phylo-evolve_surf_dstream.pqt"
 # do reconstruction
 ls "${genome_df_path}" | python3 -m \
     hstrat.dataframe.surface_unpack_reconstruct \
+    --exploded-slice-size 100000 \
     "${reconst_phylo_df_path}" \
     >/dev/null 2>&1
 

--- a/examples/surface_build_tree_cli.sh
+++ b/examples/surface_build_tree_cli.sh
@@ -9,6 +9,7 @@ wget -O /tmp/hstrat-examples-genomes.pqt https://osf.io/gnkbc/download
 ls -1 /tmp/hstrat-examples-genomes.pqt \
     | python3 -O -m hstrat.dataframe.surface_build_tree \
         --head 100_000 \
+        --exploded-slice-size 100000 \
         /tmp/reconstructed.csv
 
 # convert from alifestd to newick

--- a/examples/surface_unpack_reconstruct_cli.sh
+++ b/examples/surface_unpack_reconstruct_cli.sh
@@ -10,4 +10,5 @@ wget -O /tmp/genomes.pqt https://osf.io/gnkbc/download
 # as it incorporates key postprocessing steps
 ls -1 /tmp/genomes.pqt \
     | python3 -O -m hstrat.dataframe.surface_unpack_reconstruct \
+     --exploded-slice-size 100000 \
      /tmp/reconstruct1.csv


### PR DESCRIPTION
This PR updates example scripts to include the `--exploded-slice-size 100000` parameter when invoking surface reconstruction and tree building CLI commands.

## Summary
Three example scripts have been updated to pass an explicit `--exploded-slice-size` parameter with a value of 100000 to the hstrat dataframe surface processing modules. This ensures consistent and predictable behavior across example runs.

## Changes Made
- `examples/end2end_tree_reconstruction_with_dstream_surf.sh`: Added `--exploded-slice-size 100000` to `surface_unpack_reconstruct` invocation
- `examples/surface_build_tree_cli.sh`: Added `--exploded-slice-size 100000` to `surface_build_tree` invocation
- `examples/surface_unpack_reconstruct_cli.sh`: Added `--exploded-slice-size 100000` to `surface_unpack_reconstruct` invocation

## Details
The `--exploded-slice-size` parameter controls the batch size for processing exploded slices during surface reconstruction operations. Setting this to 100000 provides a reasonable default that balances memory usage and performance for the example datasets.

https://claude.ai/code/session_013nNAeErx6kMNkJYxSFqogY