### PR TITLE
Cache OSF genome data in CI and example scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.10"
+    - name: Cache OSF genome data
+      uses: actions/cache@v4
+      with:
+        path: /tmp/hstrat-gnkbc.pqt
+        key: osf-gnkbc
     - name: Install Python dependencies
       uses: py-actions/py-dependency-install@v4
       with:

--- a/examples/surface_build_tree_cli.sh
+++ b/examples/surface_build_tree_cli.sh
@@ -3,7 +3,9 @@
 set -euo pipefail
 
 # get example genome data
-wget -O /tmp/hstrat-examples-genomes.pqt https://osf.io/gnkbc/download
+cp /tmp/hstrat-gnkbc.pqt /tmp/hstrat-examples-genomes.pqt 2>/dev/null \
+    || { wget -O /tmp/hstrat-examples-genomes.pqt https://osf.io/gnkbc/download \
+    && cp /tmp/hstrat-examples-genomes.pqt /tmp/hstrat-gnkbc.pqt; }
 
 # unpack and reconstruct, only first 100_000 genomes for this example
 ls -1 /tmp/hstrat-examples-genomes.pqt \

--- a/examples/surface_unpack_reconstruct_cli.sh
+++ b/examples/surface_unpack_reconstruct_cli.sh
@@ -3,7 +3,9 @@
 set -euo pipefail
 
 # get example genome data
-wget -O /tmp/genomes.pqt https://osf.io/gnkbc/download
+cp /tmp/hstrat-gnkbc.pqt /tmp/genomes.pqt 2>/dev/null \
+    || { wget -O /tmp/genomes.pqt https://osf.io/gnkbc/download \
+    && cp /tmp/genomes.pqt /tmp/hstrat-gnkbc.pqt; }
 
 # unpack and reconstruct
 # note: in most cases the surface_build_tree cli should be preferred,


### PR DESCRIPTION
## Summary
This PR implements caching of the OSF genome dataset to improve CI performance and reduce redundant downloads across workflow runs and example script executions.

## Key Changes
- **CI Workflow**: Added a caching step in the GitHub Actions workflow to cache the OSF genome data (`/tmp/hstrat-gnkbc.pqt`) with key `osf-gnkbc`
- **Example Scripts**: Updated both `surface_build_tree_cli.sh` and `surface_unpack_reconstruct_cli.sh` to:
  - First attempt to use the cached genome data from `/tmp/hstrat-gnkbc.pqt`
  - Fall back to downloading from OSF if the cache is not available
  - Save downloaded data to the cache location for future use

## Implementation Details
The example scripts now use a copy-or-download pattern with error handling:
- Attempts to copy from the cache location (silently fails if not present)
- Falls back to `wget` download if cache miss occurs
- Automatically populates the cache after a successful download for subsequent runs

This approach ensures backward compatibility while providing significant performance improvements in CI environments and repeated local executions.

https://claude.ai/code/session_01CVHrRmEKzggpo2NqgT1fYu