### PR TITLE
Add multiprocessing pool support for parallel slice explosion

### DIFF
--- a/hstrat/dataframe/_surface_build_tree.py
+++ b/hstrat/dataframe/_surface_build_tree.py
@@ -16,6 +16,7 @@ def surface_build_tree(
     check_trie_invariant_after_collapse_unif: bool = False,
     exploded_slice_size: int = 1_000_000,
     mp_context: str = "spawn",
+    mp_pool_size: int = 1,
     pa_source_type: str = "memory_map",
     delete_trunk: bool = True,
     trie_postprocessor: typing.Callable = NopTriePostprocessor(),
@@ -77,6 +78,13 @@ def surface_build_tree(
 
     mp_context : str, default 'spawn'
         Multiprocessing context to use for parallel processing.
+
+    mp_pool_size : int, default 1
+        Number of worker processes for exploding slices in parallel.
+
+        When 1, a single producer process is used (original behavior).
+        When greater than 1, a multiprocessing pool is used with ordered
+        results via ``Pool.imap``.
 
     pa_source_type : str, default 'memory_map'
         PyArrow type to use for exploded chunks (i.e., "memory_map" or
@@ -140,6 +148,7 @@ def surface_build_tree(
         check_trie_invariant_after_collapse_unif=check_trie_invariant_after_collapse_unif,
         exploded_slice_size=exploded_slice_size,
         mp_context=mp_context,
+        mp_pool_size=mp_pool_size,
         pa_source_type=pa_source_type,
     )
 

--- a/hstrat/dataframe/_surface_unpack_reconstruct.py
+++ b/hstrat/dataframe/_surface_unpack_reconstruct.py
@@ -1,7 +1,6 @@
 import contextlib
 import gc
 import logging
-import math
 import multiprocessing
 import pathlib
 import typing

--- a/hstrat/dataframe/_surface_unpack_reconstruct.py
+++ b/hstrat/dataframe/_surface_unpack_reconstruct.py
@@ -200,9 +200,7 @@ def _explode_and_write_slice(
     Parameters are passed as a tuple for compatibility with Pool.imap.
     """
     df_slice, num_slices, slice_index = args
-    logging.info(
-        f"- worker exploding slice {slice_index + 1} / {num_slices}"
-    )
+    logging.info(f"- worker exploding slice {slice_index + 1} / {num_slices}")
     # apply explode transformation
     long_df = _make_exploded_slice(
         df_slice=df_slice,
@@ -606,7 +604,11 @@ def _generate_exploded_slices_mp(
         logging.info("spawning exploded df worker")
         producer = mp_context.Process(
             target=_produce_exploded_slices,
-            args=(queue, df, exploded_slice_size),  # lazyframe is cheap to send
+            args=(
+                queue,
+                df,
+                exploded_slice_size,
+            ),  # lazyframe is cheap to send
         )
         logging.info("starting exploded df worker")
         producer.start()
@@ -626,9 +628,7 @@ def _generate_exploded_slices_mp(
 
         producer.join()  # wait for producer to finish (no effect, but good form)
     else:
-        logging.info(
-            f"using multiprocessing pool with {mp_pool_size} workers"
-        )
+        logging.info(f"using multiprocessing pool with {mp_pool_size} workers")
         df, num_slices = _prepare_df_for_explosion(df, exploded_slice_size)
 
         def _slice_args():

--- a/hstrat/dataframe/_surface_unpack_reconstruct.py
+++ b/hstrat/dataframe/_surface_unpack_reconstruct.py
@@ -1,4 +1,5 @@
 import contextlib
+import gc
 import logging
 import math
 import multiprocessing
@@ -198,6 +199,7 @@ def _explode_and_write_slice(args: typing.Tuple[pl.LazyFrame, slice]) -> str:
         outpath, compression="uncompressed"
     )
     del long_df  # clear memory
+    gc.collect()
     return outpath
 
 
@@ -575,6 +577,7 @@ def _generate_exploded_slices_mp(
     logging.info(f"writing prepared df ({nrows_log} rows) to {df_path}")
     df.write_ipc(df_path, compression="uncompressed")
     del df
+    gc.collect()
 
     try:
         logging.info(f"scanning {df_path}")

--- a/hstrat/dataframe/surface_build_tree.py
+++ b/hstrat/dataframe/surface_build_tree.py
@@ -147,6 +147,15 @@ def _create_parser() -> argparse.ArgumentParser:
         help="Number of rows to process at once. Low values reduce memory use.",
     )
     parser.add_argument(
+        "--mp-pool-size",
+        type=int,
+        default=1,
+        help=(
+            "Number of worker processes for exploding slices in parallel. "
+            "Default 1 (single producer process)."
+        ),
+    )
+    parser.add_argument(
         "--delete-trunk",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -206,6 +215,7 @@ def _main(mp_context: str) -> None:
                 delete_trunk=args.delete_trunk,
                 exploded_slice_size=args.exploded_slice_size,
                 mp_context=mp_context,
+                mp_pool_size=args.mp_pool_size,
                 pa_source_type=args.pa_source_type,
                 trie_postprocessor=trie_postprocessor,
             ),

--- a/hstrat/dataframe/surface_unpack_reconstruct.py
+++ b/hstrat/dataframe/surface_unpack_reconstruct.py
@@ -182,6 +182,15 @@ def _create_parser() -> argparse.ArgumentParser:
         default=1_000_000,
         help="Number of rows to process at once. Low values reduce memory use.",
     )
+    parser.add_argument(
+        "--mp-pool-size",
+        type=int,
+        default=1,
+        help=(
+            "Number of worker processes for exploding slices in parallel. "
+            "Default 1 (single producer process)."
+        ),
+    )
     add_bool_arg(
         parser,
         "drop-dstream-metadata",
@@ -221,6 +230,7 @@ def _main(mp_context: str) -> None:
                 drop_dstream_metadata=args.drop_dstream_metadata,
                 exploded_slice_size=args.exploded_slice_size,
                 mp_context=mp_context,
+                mp_pool_size=args.mp_pool_size,
                 pa_source_type=args.pa_source_type,
             ),
         )

--- a/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct.py
+++ b/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct.py
@@ -30,6 +30,21 @@ def test_smoke(pa_source_type: str):
     )
 
 
+@pytest.mark.parametrize("mp_pool_size", [1, 2])
+def test_mp_pool_size(mp_pool_size: int):
+    df = pl.read_csv(f"{assets_path}/packed.csv")
+    res = surface_unpack_reconstruct(df, mp_pool_size=mp_pool_size)
+    assert len(res) > len(df)
+    assert alifestd_validate(
+        alifestd_try_add_ancestor_list_col(res.to_pandas()),
+    )
+    assert alifestd_is_chronologically_ordered(
+        alifestd_try_add_ancestor_list_col(
+            res.with_columns(origin_time=pl.col("dstream_rank")).to_pandas(),
+        ),
+    )
+
+
 def test_drop_dstream_metadata_default():
     """Default behavior (None) should drop dstream/downstream columns."""
     df = pl.read_csv(f"{assets_path}/packed.csv")

--- a/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct_cli.py
+++ b/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct_cli.py
@@ -166,6 +166,26 @@ def test_surface_unpack_reconstruct_cli_check_trie_invariant_freq_zero():
     assert os.path.exists(output_file)
 
 
+def test_surface_unpack_reconstruct_cli_mp_pool_size():
+    output_file = (
+        "/tmp/hstrat_unpack_surface_reconstruct_pool.csv"  # nosec B108
+    )
+    pathlib.Path(output_file).unlink(missing_ok=True)
+    subprocess.run(  # nosec B603
+        [
+            "python3",
+            "-m",
+            "hstrat.dataframe.surface_unpack_reconstruct",
+            output_file,
+            "--mp-pool-size",
+            "2",
+        ],
+        check=True,
+        input=f"{assets}/packed.csv".encode(),
+    )
+    assert os.path.exists(output_file)
+
+
 def test_surface_unpack_reconstruct_cli_drop_dstream_metadata_fails():
     output_file = (
         "/tmp/hstrat_unpack_surface_reconstruct_drop.pqt"  # nosec B108


### PR DESCRIPTION
## Summary
This PR adds support for parallel processing of DataFrame slices using a multiprocessing pool, while maintaining backward compatibility with the existing single-producer queue-based approach.

## Key Changes

- **Refactored slice explosion logic**: Split `_produce_exploded_slices` into two functions:
  - `_prepare_df_for_explosion`: Handles unpacking, sorting, and preparation of the DataFrame
  - `_explode_and_write_slice`: Processes a single slice and writes results to a temporary Arrow file (compatible with `Pool.imap`)

- **Added `mp_pool_size` parameter**: New optional parameter (default=1) to control parallelization strategy:
  - When `mp_pool_size=1`: Uses original single-producer process with queue (default behavior)
  - When `mp_pool_size>1`: Uses multiprocessing pool with ordered results via `Pool.imap`

- **Updated `_generate_exploded_slices_mp`**: Conditional logic to support both execution paths based on `mp_pool_size`

- **CLI updates**: Added `--mp-pool-size` argument to both `surface_unpack_reconstruct` and `surface_build_tree` command-line interfaces

- **Documentation**: Added docstring for new parameter explaining the behavior and use cases

- **Tests**: Added parametrized test (`test_mp_pool_size`) and CLI test (`test_surface_unpack_reconstruct_cli_mp_pool_size`) to verify both single and multi-worker configurations

## Implementation Details

- The refactoring maintains the temporary Arrow file approach for inter-process communication, which is more efficient than direct queue passing
- Pool-based approach uses `imap` to maintain slice ordering while processing in parallel
- Backward compatible: existing code using default parameters continues to work unchanged
- Memory management preserved with explicit `del` statements in slice explosion function

https://claude.ai/code/session_01UXdGPARAQr3V3M6LqSAmL6