### PR TITLE
Configure logging in multiprocessing pool workers

### DIFF
--- a/hstrat/dataframe/_surface_unpack_reconstruct.py
+++ b/hstrat/dataframe/_surface_unpack_reconstruct.py
@@ -14,6 +14,7 @@ import pyarrow as pa
 import tqdm
 
 from .._auxiliary_lib import (
+    configure_prod_logging,
     get_sole_scalar_value_polars,
     give_len,
     iter_slices,
@@ -591,7 +592,10 @@ def _generate_exploded_slices_mp(
         logging.info(
             f"creating multiprocessing pool with {mp_pool_size} workers",
         )
-        with mp_context.Pool(processes=mp_pool_size) as pool:
+        with mp_context.Pool(
+            processes=mp_pool_size,
+            initializer=configure_prod_logging,
+        ) as pool:
             yield give_len(
                 pool.imap(
                     _explode_and_write_slice,


### PR DESCRIPTION
## Summary
This change ensures that logging is properly configured in multiprocessing worker processes by adding an initializer function to the multiprocessing pool.

## Key Changes
- Import `configure_prod_logging` from the auxiliary library
- Pass `configure_prod_logging` as the `initializer` parameter when creating the multiprocessing pool in `_generate_exploded_slices_mp()`

## Implementation Details
The `configure_prod_logging` function is now called once when each worker process starts, ensuring that all logging output from worker processes is properly configured according to production standards. This prevents logging configuration issues that can occur when worker processes inherit incomplete or incorrect logging state from the parent process.

https://claude.ai/code/session_01JptzPESsWvDWacozRMTHJZ