### PR TITLE
Handle empty dataframes and single genomes in phylogeny functions

### DIFF
--- a/hstrat/dataframe/_surface_postprocess_trie.py
+++ b/hstrat/dataframe/_surface_postprocess_trie.py
@@ -25,18 +25,14 @@ from ._surface_postprocess_trie_via_pandas import (
 
 def _apply_empty_output_schema(df: pl.DataFrame) -> pl.DataFrame:
     """Transform an empty trie DataFrame to match the postprocessed output
-    schema: add ``hstrat_rank`` and drop internal-only columns.
-
-    Also casts ``ancestor_id`` to ``Int64`` to match the type produced by
-    phyloframe's ``alifestd_assign_contiguous_ids_polars`` in the non-empty
-    path.
-    """
+    schema: add ``hstrat_rank`` and drop internal-only columns."""
     if "dstream_rank" in df.columns and "dstream_S" in df.columns:
         df = df.with_columns(
             hstrat_rank=pl.col("dstream_rank") - pl.col("dstream_S"),
         )
+    # phyloframe may have cast ancestor_id to Int64; restore documented UInt64
     if "ancestor_id" in df.columns:
-        df = df.with_columns(pl.col("ancestor_id").cast(pl.Int64))
+        df = df.with_columns(pl.col("ancestor_id").cast(pl.UInt64))
     df = df.drop(
         "dstream_S",
         "hstrat_differentia_bitwidth",
@@ -313,6 +309,10 @@ def surface_postprocess_trie(
     to_drop = pre_postprocessor_columns - to_keep
     logging.info(f"dropping columns {to_drop=}...")
     df = df.drop(*to_drop)
+
+    # phyloframe may convert ancestor_id to Int64; restore documented UInt64
+    if "ancestor_id" in df.columns:
+        df = df.with_columns(pl.col("ancestor_id").cast(pl.UInt64))
 
     render_polars_snapshot(df, "as polars", logging.info)
     gc.collect()

--- a/hstrat/dataframe/_surface_postprocess_trie.py
+++ b/hstrat/dataframe/_surface_postprocess_trie.py
@@ -66,6 +66,12 @@ def _do_delete_trunk(
     with log_context_duration("alifestd_delete_trunk_asexual", logging.info):
         df = pfl.alifestd_delete_trunk_asexual_polars(df)
 
+    if df.lazy().limit(1).collect().is_empty():
+        logging.info("empty dataframe after trunk deletion")
+        return df.drop(
+            ["is_trunk", "ancestor_is_trunk", "origin_time"], strict=False
+        )
+
     logging.info(f" - len(df): {df.lazy().select(pl.len()).collect().item()}")
     with log_context_duration("alifestd_assign_contiguous_ids", logging.info):
         df = pfl.alifestd_assign_contiguous_ids_polars(df)
@@ -233,6 +239,10 @@ def surface_postprocess_trie(
     log_memory_usage(logging.info)
     render_polars_snapshot(df, "raw tree", logging.info)
 
+    if df.lazy().limit(1).collect().is_empty():
+        logging.info("empty input dataframe, returning empty result")
+        return df
+
     logging.info("extracting differentia bitwidth")
     differentia_bitwidth = get_sole_scalar_value_polars(
         df, "hstrat_differentia_bitwidth"
@@ -243,6 +253,10 @@ def surface_postprocess_trie(
 
     if delete_trunk:
         df = _do_delete_trunk(df)
+
+    if df.lazy().limit(1).collect().is_empty():
+        logging.info("empty dataframe after trunk deletion, returning")
+        return df
 
     df = _do_collapse_unifurcations(df)
 

--- a/hstrat/dataframe/_surface_postprocess_trie.py
+++ b/hstrat/dataframe/_surface_postprocess_trie.py
@@ -28,9 +28,9 @@ def _apply_empty_output_schema(df: pl.DataFrame) -> pl.DataFrame:
     schema: add ``hstrat_rank`` and drop internal-only columns."""
     assert df.is_empty(), "expected empty DataFrame"
     df = df.with_columns(
+        ancestor_id=pl.col("ancestor_id").cast(pl.UInt64),
         hstrat_rank=pl.lit(None, dtype=pl.UInt64),
     )
-    df = df.with_columns(pl.col("ancestor_id").cast(pl.UInt64))
     return df.drop(
         "dstream_S",
         "hstrat_differentia_bitwidth",
@@ -308,8 +308,7 @@ def surface_postprocess_trie(
     df = df.drop(*to_drop)
 
     # phyloframe may convert ancestor_id to Int64; restore documented UInt64
-    if "ancestor_id" in df.columns:
-        df = df.with_columns(pl.col("ancestor_id").cast(pl.UInt64))
+    df = df.cast({"ancestor_id": pl.UInt64})
 
     render_polars_snapshot(df, "as polars", logging.info)
     gc.collect()

--- a/hstrat/dataframe/_surface_postprocess_trie.py
+++ b/hstrat/dataframe/_surface_postprocess_trie.py
@@ -26,7 +26,7 @@ from ._surface_postprocess_trie_via_pandas import (
 def _apply_empty_output_schema(df: pl.DataFrame) -> pl.DataFrame:
     """Transform an empty trie DataFrame to match the postprocessed output
     schema: add ``hstrat_rank`` and drop internal-only columns."""
-    assert df.is_empty(), "expected empty DataFrame"
+    assert df.is_empty()
     df = df.with_columns(
         ancestor_id=pl.col("ancestor_id").cast(pl.UInt64),
         hstrat_rank=pl.lit(None, dtype=pl.UInt64),

--- a/hstrat/dataframe/_surface_postprocess_trie.py
+++ b/hstrat/dataframe/_surface_postprocess_trie.py
@@ -23,6 +23,29 @@ from ._surface_postprocess_trie_via_pandas import (
 )
 
 
+def _apply_empty_output_schema(df: pl.DataFrame) -> pl.DataFrame:
+    """Transform an empty trie DataFrame to match the postprocessed output
+    schema: add ``hstrat_rank`` and drop internal-only columns.
+
+    Also casts ``ancestor_id`` to ``Int64`` to match the type produced by
+    phyloframe's ``alifestd_assign_contiguous_ids_polars`` in the non-empty
+    path.
+    """
+    if "dstream_rank" in df.columns and "dstream_S" in df.columns:
+        df = df.with_columns(
+            hstrat_rank=pl.col("dstream_rank") - pl.col("dstream_S"),
+        )
+    if "ancestor_id" in df.columns:
+        df = df.with_columns(pl.col("ancestor_id").cast(pl.Int64))
+    df = df.drop(
+        "dstream_S",
+        "hstrat_differentia_bitwidth",
+        "dstream_rank",
+        strict=False,
+    )
+    return df
+
+
 def _do_collapse_unifurcations(
     df: pl.DataFrame,
 ) -> pl.DataFrame:
@@ -67,7 +90,7 @@ def _do_delete_trunk(
         df = pfl.alifestd_delete_trunk_asexual_polars(df)
 
     if df.lazy().limit(1).collect().is_empty():
-        logging.info("empty dataframe after trunk deletion")
+        logging.warning("empty dataframe after trunk deletion")
         return df.drop(
             ["is_trunk", "ancestor_is_trunk", "origin_time"], strict=False
         )
@@ -240,8 +263,8 @@ def surface_postprocess_trie(
     render_polars_snapshot(df, "raw tree", logging.info)
 
     if df.lazy().limit(1).collect().is_empty():
-        logging.info("empty input dataframe, returning empty result")
-        return df
+        logging.warning("empty input dataframe, returning empty result")
+        return _apply_empty_output_schema(df)
 
     logging.info("extracting differentia bitwidth")
     differentia_bitwidth = get_sole_scalar_value_polars(
@@ -255,8 +278,8 @@ def surface_postprocess_trie(
         df = _do_delete_trunk(df)
 
     if df.lazy().limit(1).collect().is_empty():
-        logging.info("empty dataframe after trunk deletion, returning")
-        return df
+        logging.warning("empty dataframe after trunk deletion, returning")
+        return _apply_empty_output_schema(df)
 
     df = _do_collapse_unifurcations(df)
 

--- a/hstrat/dataframe/_surface_postprocess_trie.py
+++ b/hstrat/dataframe/_surface_postprocess_trie.py
@@ -26,20 +26,17 @@ from ._surface_postprocess_trie_via_pandas import (
 def _apply_empty_output_schema(df: pl.DataFrame) -> pl.DataFrame:
     """Transform an empty trie DataFrame to match the postprocessed output
     schema: add ``hstrat_rank`` and drop internal-only columns."""
-    if "dstream_rank" in df.columns and "dstream_S" in df.columns:
-        df = df.with_columns(
-            hstrat_rank=pl.col("dstream_rank") - pl.col("dstream_S"),
-        )
-    # phyloframe may have cast ancestor_id to Int64; restore documented UInt64
-    if "ancestor_id" in df.columns:
-        df = df.with_columns(pl.col("ancestor_id").cast(pl.UInt64))
-    df = df.drop(
+    assert df.is_empty(), "expected empty DataFrame"
+    df = df.with_columns(
+        hstrat_rank=pl.lit(None, dtype=pl.UInt64),
+    )
+    df = df.with_columns(pl.col("ancestor_id").cast(pl.UInt64))
+    return df.drop(
         "dstream_S",
         "hstrat_differentia_bitwidth",
         "dstream_rank",
         strict=False,
     )
-    return df
 
 
 def _do_collapse_unifurcations(

--- a/hstrat/dataframe/_surface_postprocess_trie_via_pandas.py
+++ b/hstrat/dataframe/_surface_postprocess_trie_via_pandas.py
@@ -54,6 +54,14 @@ def _do_delete_trunk(
     with log_context_duration("alifestd_delete_trunk_asexual", logging.info):
         df = pfl.alifestd_delete_trunk_asexual(df, mutate=True)
 
+    if df.empty:
+        logging.info("empty dataframe after trunk deletion")
+        df = df.drop(
+            columns=["is_trunk", "ancestor_is_trunk", "origin_time"],
+            errors="ignore",
+        )
+        return df
+
     with log_context_duration("alifestd_assign_contiguous_ids", logging.info):
         df = pfl.alifestd_assign_contiguous_ids(df, mutate=True)
 
@@ -97,6 +105,10 @@ def _surface_postprocess_trie_via_pandas(
     log_memory_usage(logging.info)
     render_polars_snapshot(df, "raw tree", logging.info)
 
+    if df.lazy().limit(1).collect().is_empty():
+        logging.info("empty input dataframe, returning empty result")
+        return df
+
     logging.info("extracting differentia bitwidth")
     differentia_bitwidth = get_sole_scalar_value_polars(
         df, "hstrat_differentia_bitwidth"
@@ -112,6 +124,10 @@ def _surface_postprocess_trie_via_pandas(
 
     if delete_trunk:
         df = _do_delete_trunk(df)
+
+    if df.empty:
+        logging.info("empty dataframe after trunk deletion, returning")
+        return pl.from_pandas(df)
 
     df = _do_collapse_unifurcations(df)
 

--- a/hstrat/dataframe/_surface_postprocess_trie_via_pandas.py
+++ b/hstrat/dataframe/_surface_postprocess_trie_via_pandas.py
@@ -22,6 +22,9 @@ def _apply_empty_output_schema_pandas(df: pd.DataFrame) -> pd.DataFrame:
     schema: add ``hstrat_rank`` and drop internal-only columns."""
     if "dstream_rank" in df.columns and "dstream_S" in df.columns:
         df["hstrat_rank"] = df["dstream_rank"] - df["dstream_S"]
+    # phyloframe may have cast ancestor_id to int64; restore documented uint64
+    if "ancestor_id" in df.columns:
+        df["ancestor_id"] = df["ancestor_id"].astype("uint64")
     df = df.drop(
         columns=["dstream_S", "hstrat_differentia_bitwidth", "dstream_rank"],
         errors="ignore",
@@ -176,6 +179,11 @@ def _surface_postprocess_trie_via_pandas(
     logging.info("converting DataFrame to Polars...")
     with log_context_duration("pl.from_pandas", logging.info):
         df = pl.from_pandas(df)
+
+    # phyloframe may convert ancestor_id to Int64; restore documented UInt64
+    if "ancestor_id" in df.columns:
+        df = df.with_columns(pl.col("ancestor_id").cast(pl.UInt64))
+
     gc.collect()
     render_polars_snapshot(df, "as polars", logging.info)
     log_memory_usage(logging.info)

--- a/hstrat/dataframe/_surface_postprocess_trie_via_pandas.py
+++ b/hstrat/dataframe/_surface_postprocess_trie_via_pandas.py
@@ -17,6 +17,18 @@ from .._auxiliary_lib import (
 from ..phylogenetic_inference.tree.trie_postprocess import NopTriePostprocessor
 
 
+def _apply_empty_output_schema_pandas(df: pd.DataFrame) -> pd.DataFrame:
+    """Transform an empty trie DataFrame to match the postprocessed output
+    schema: add ``hstrat_rank`` and drop internal-only columns."""
+    if "dstream_rank" in df.columns and "dstream_S" in df.columns:
+        df["hstrat_rank"] = df["dstream_rank"] - df["dstream_S"]
+    df = df.drop(
+        columns=["dstream_S", "hstrat_differentia_bitwidth", "dstream_rank"],
+        errors="ignore",
+    )
+    return df
+
+
 def _do_collapse_unifurcations(
     df: pd.DataFrame,
 ) -> pd.DataFrame:
@@ -55,7 +67,7 @@ def _do_delete_trunk(
         df = pfl.alifestd_delete_trunk_asexual(df, mutate=True)
 
     if df.empty:
-        logging.info("empty dataframe after trunk deletion")
+        logging.warning("empty dataframe after trunk deletion")
         df = df.drop(
             columns=["is_trunk", "ancestor_is_trunk", "origin_time"],
             errors="ignore",
@@ -106,8 +118,10 @@ def _surface_postprocess_trie_via_pandas(
     render_polars_snapshot(df, "raw tree", logging.info)
 
     if df.lazy().limit(1).collect().is_empty():
-        logging.info("empty input dataframe, returning empty result")
-        return df
+        logging.warning("empty input dataframe, returning empty result")
+        from ._surface_postprocess_trie import _apply_empty_output_schema
+
+        return _apply_empty_output_schema(df)
 
     logging.info("extracting differentia bitwidth")
     differentia_bitwidth = get_sole_scalar_value_polars(
@@ -126,8 +140,8 @@ def _surface_postprocess_trie_via_pandas(
         df = _do_delete_trunk(df)
 
     if df.empty:
-        logging.info("empty dataframe after trunk deletion, returning")
-        return pl.from_pandas(df)
+        logging.warning("empty dataframe after trunk deletion, returning")
+        return pl.from_pandas(_apply_empty_output_schema_pandas(df))
 
     df = _do_collapse_unifurcations(df)
 

--- a/hstrat/dataframe/_surface_unpack_reconstruct.py
+++ b/hstrat/dataframe/_surface_unpack_reconstruct.py
@@ -7,8 +7,6 @@ import typing
 import uuid
 
 from downstream import dataframe as dstream_dataframe
-import pandas as pd
-from phyloframe import legacy as pfl
 import polars as pl
 import pyarrow as pa
 import tqdm
@@ -738,13 +736,30 @@ def surface_unpack_reconstruct(
 
     # for simplicity, return early for this special case
     if df.lazy().limit(1).collect().is_empty():
-        logging.info("empty input dataframe, returning empty result")
-        res = pfl.alifestd_make_empty()
-        res["taxon_label"] = None
-        res["dstream_rank"] = pd.Series(dtype=int)
-        res["hstrat_differentia_bitwidth"] = pd.Series(dtype=int)
-        res["dstream_S"] = pd.Series(dtype=int)
-        return pl.from_pandas(res)
+        logging.warning("empty input dataframe, returning empty result")
+        core_schema = {
+            "dstream_data_id": pl.UInt64,
+            "id": pl.UInt64,
+            "ancestor_id": pl.UInt64,
+            "dstream_rank": pl.UInt64,
+            "hstrat_differentia_bitwidth": pl.UInt32,
+            "dstream_S": pl.UInt32,
+        }
+        result = pl.DataFrame(schema=core_schema)
+        # forward user-defined columns with matching (empty) types
+        if isinstance(df, pl.LazyFrame):
+            input_schema = df.collect_schema()
+        else:
+            input_schema = df.schema
+        dstream_re = {"dstream_", "downstream_"}
+        for col_name, col_type in input_schema.items():
+            if col_name not in result.columns and not any(
+                col_name.startswith(p) for p in dstream_re
+            ):
+                result = result.with_columns(
+                    pl.Series(col_name, [], dtype=col_type),
+                )
+        return result
 
     logging.info("extracting metadata...")
     dstream_storage_bitwidth = get_sole_scalar_value_polars(

--- a/hstrat/dataframe/_surface_unpack_reconstruct.py
+++ b/hstrat/dataframe/_surface_unpack_reconstruct.py
@@ -746,19 +746,16 @@ def surface_unpack_reconstruct(
             "dstream_S": pl.UInt32,
         }
         result = pl.DataFrame(schema=core_schema)
-        # forward user-defined columns with matching (empty) types
-        if isinstance(df, pl.LazyFrame):
-            input_schema = df.collect_schema()
-        else:
-            input_schema = df.schema
-        dstream_re = {"dstream_", "downstream_"}
-        for col_name, col_type in input_schema.items():
-            if col_name not in result.columns and not any(
-                col_name.startswith(p) for p in dstream_re
-            ):
-                result = result.with_columns(
-                    pl.Series(col_name, [], dtype=col_type),
-                )
+        try:
+            result = _join_user_defined_columns(
+                df, result, drop_dstream_metadata
+            )
+        except pl.exceptions.ColumnNotFoundError:
+            result = _join_user_defined_columns(
+                df.with_row_index("dstream_data_id"),
+                result,
+                drop_dstream_metadata,
+            )
         return result
 
     logging.info("extracting metadata...")

--- a/tests/test_hstrat/test_dataframe/test_surface_build_tree.py
+++ b/tests/test_hstrat/test_dataframe/test_surface_build_tree.py
@@ -28,12 +28,24 @@ def test_smoke():
     assert pfl.alifestd_is_chronologically_ordered(res.to_pandas())
 
 
+def _get_full_schema():
+    """Get expected output schema from a known-good two-genome run."""
+    df = pl.read_csv(f"{assets_path}/packed.csv")
+    return surface_build_tree(df, collapse_unif_freq=0).schema
+
+
 def test_empty():
     """Regression: empty genome set should produce an empty phylogeny without
-    crashing."""
+    crashing, with the same columns and types as a non-empty result."""
     df = pl.read_csv(f"{assets_path}/packed.csv").head(0)
     res = surface_build_tree(df)
     assert len(res) == 0
+    full_schema = _get_full_schema()
+    assert set(res.schema.names()) == set(full_schema.names())
+    for col in full_schema.names():
+        assert (
+            res.schema[col] == full_schema[col]
+        ), f"type mismatch for {col}: {res.schema[col]} != {full_schema[col]}"
 
 
 def test_single_genome():
@@ -48,6 +60,14 @@ def test_single_genome():
     )
     # single genome may produce empty tree after trunk deletion
     assert isinstance(res, pl.DataFrame)
+    if len(res) == 0:
+        full_schema = _get_full_schema()
+        assert set(res.schema.names()) == set(full_schema.names())
+        for col in full_schema.names():
+            assert res.schema[col] == full_schema[col], (
+                f"type mismatch for {col}: "
+                f"{res.schema[col]} != {full_schema[col]}"
+            )
 
 
 def test_single_genome_no_delete_trunk():

--- a/tests/test_hstrat/test_dataframe/test_surface_build_tree.py
+++ b/tests/test_hstrat/test_dataframe/test_surface_build_tree.py
@@ -26,3 +26,44 @@ def test_smoke():
         pfl.alifestd_try_add_ancestor_list_col(res.to_pandas()),
     )
     assert pfl.alifestd_is_chronologically_ordered(res.to_pandas())
+
+
+def test_empty():
+    """Regression: empty genome set should produce an empty phylogeny without
+    crashing."""
+    df = pl.read_csv(f"{assets_path}/packed.csv").head(0)
+    res = surface_build_tree(df)
+    assert len(res) == 0
+
+
+def test_single_genome():
+    """Regression: a single genome should not crash."""
+    df = pl.read_csv(f"{assets_path}/packed.csv").head(1)
+    res = surface_build_tree(
+        df,
+        collapse_unif_freq=0,
+        trie_postprocessor=AssignOriginTimeNodeRankTriePostprocessor(
+            t0="dstream_S",
+        ),
+    )
+    # single genome may produce empty tree after trunk deletion
+    assert isinstance(res, pl.DataFrame)
+
+
+def test_single_genome_no_delete_trunk():
+    """Regression: a single genome without trunk deletion should produce a
+    valid phylogeny."""
+    df = pl.read_csv(f"{assets_path}/packed.csv").head(1)
+    res = surface_build_tree(
+        df,
+        collapse_unif_freq=0,
+        delete_trunk=False,
+        trie_postprocessor=AssignOriginTimeNodeRankTriePostprocessor(
+            t0="dstream_S",
+        ),
+    )
+    assert len(res) >= 1
+    assert pfl.alifestd_validate(
+        pfl.alifestd_try_add_ancestor_list_col(res.to_pandas()),
+    )
+    assert pfl.alifestd_is_chronologically_ordered(res.to_pandas())

--- a/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct.py
+++ b/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct.py
@@ -89,6 +89,29 @@ def test_parser_no_prefix_matching_drop():
     assert "awoo" in remaining
 
 
+def test_empty():
+    """Regression: empty genome set should produce an empty phylogeny without
+    crashing."""
+    df = pl.read_csv(f"{assets_path}/packed.csv").head(0)
+    res = surface_unpack_reconstruct(df)
+    assert len(res) == 0
+
+
+def test_single_genome():
+    """Regression: a single genome should produce a valid phylogeny."""
+    df = pl.read_csv(f"{assets_path}/packed.csv").head(1)
+    res = surface_unpack_reconstruct(df)
+    assert len(res) >= 1
+    assert pfl.alifestd_validate(
+        pfl.alifestd_try_add_ancestor_list_col(res.to_pandas()),
+    )
+    assert pfl.alifestd_is_chronologically_ordered(
+        pfl.alifestd_try_add_ancestor_list_col(
+            res.with_columns(origin_time=pl.col("dstream_rank")).to_pandas(),
+        ),
+    )
+
+
 def test_drop_dstream_metadata_false():
     """Passing drop_dstream_metadata=False should retain dstream columns."""
     df = pl.read_csv(f"{assets_path}/packed.csv")

--- a/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct.py
+++ b/tests/test_hstrat/test_dataframe/test_surface_unpack_reconstruct.py
@@ -91,10 +91,17 @@ def test_parser_no_prefix_matching_drop():
 
 def test_empty():
     """Regression: empty genome set should produce an empty phylogeny without
-    crashing."""
-    df = pl.read_csv(f"{assets_path}/packed.csv").head(0)
-    res = surface_unpack_reconstruct(df)
+    crashing, with the same columns and types as a non-empty result."""
+    df = pl.read_csv(f"{assets_path}/packed.csv")
+    full = surface_unpack_reconstruct(df)
+
+    res = surface_unpack_reconstruct(df.head(0))
     assert len(res) == 0
+    assert set(res.schema.names()) == set(full.schema.names())
+    for col in full.schema.names():
+        assert (
+            res.schema[col] == full.schema[col]
+        ), f"type mismatch for {col}: {res.schema[col]} != {full.schema[col]}"
 
 
 def test_single_genome():


### PR DESCRIPTION
## Summary
Add robustness to phylogeny tree building and reconstruction functions by properly handling edge cases with empty datasets and single genomes. These changes prevent crashes and ensure valid output for boundary conditions.

## Key Changes
- **Empty dataframe handling**: Added early returns in `surface_postprocess_trie` and `_surface_postprocess_trie_via_pandas` to detect and handle empty input dataframes gracefully
- **Post-trunk-deletion empty check**: Added checks after trunk deletion to handle cases where the tree becomes empty after removing the trunk, properly cleaning up temporary columns
- **Regression tests**: Added comprehensive test coverage for edge cases:
  - `test_empty()` in both `test_surface_build_tree.py` and `test_surface_unpack_reconstruct.py` to verify empty genome sets produce empty phylogenies without crashing
  - `test_single_genome()` in both test files to verify single genome handling
  - `test_single_genome_no_delete_trunk()` in `test_surface_build_tree.py` to verify valid phylogeny output when trunk deletion is disabled

## Implementation Details
- Empty dataframe detection uses `df.lazy().limit(1).collect().is_empty()` for efficient checking without materializing the full dataframe
- Temporary columns (`is_trunk`, `ancestor_is_trunk`, `origin_time`) are cleaned up when dataframes become empty after trunk deletion
- Both Polars and Pandas code paths are updated consistently to handle these edge cases
- Logging added at each early return point for debugging and monitoring

https://claude.ai/code/session_01LsRsKbS6bk8QbqNpxYzyPc