### PR TITLE
Fix cp311 wheel test failure by preferring binary wheels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -429,6 +429,13 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
         env:
+          # Prefer pre-built binary wheels during the test install so that
+          # scipy/scikit-learn/numpy are never built from source. Source builds
+          # of scipy fail inside the manylinux2014 test containers because no
+          # OpenBLAS is available ("Dependency OpenBLAS not found"). This env
+          # var also applies to cibuildwheel's own install of the hstrat wheel
+          # under test, which CIBW_BEFORE_TEST cannot influence on its own.
+          CIBW_ENVIRONMENT: PIP_PREFER_BINARY=1
           # workaround pyarrow wheel issue
           # pre-install scipy with --only-binary to avoid source builds
           # failing in manylinux2014 containers without OpenBLAS


### PR DESCRIPTION
The cibuildwheel test phase installed the hstrat wheel, which pulls in
scikit-learn. With a very new numpy in the venv, pip resolved scikit-learn
to a source build, which in turn built scipy from source and failed with
"Dependency OpenBLAS not found" inside the manylinux2014 test container.

Set PIP_PREFER_BINARY=1 via CIBW_ENVIRONMENT so the test install (including
cibuildwheel's own install of the wheel under test) prefers prebuilt binary
wheels for scipy/scikit-learn/numpy instead of building from source.